### PR TITLE
New internal auth token required for sdes location and owner typo correction

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreService.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreService.scala
@@ -132,7 +132,7 @@ class ObjectStoreServiceImpl @Inject() (clock: Clock, appConfig: AppConfig, clie
       client
         .getObject[Source[ByteString, NotUsed]](
           Path.File(objectStoreResourceLocation.resourceLocation),
-          "common-transit-conversion-traders"
+          "common-transit-convention-traders"
         )
         .map {
           case Right(Some(source)) => Right(source.content)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -191,5 +191,5 @@ microservice {
 
 messageSizeLimit = 500000
 object-store.default-retention-period = "7-years"
-internal-auth.token = "1234"
+internal-auth.token = "123456"
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -191,5 +191,5 @@ microservice {
 
 messageSizeLimit = 500000
 object-store.default-retention-period = "7-years"
-internal-auth.token = "123456"
+internal-auth.token = "transit-movements-router-token"
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreServiceSpec.scala
@@ -51,7 +51,7 @@ class ObjectStoreServiceSpec
     with BeforeAndAfterEach {
 
   val baseUrl = s"http://baseUrl-${randomUUID().toString}"
-  val owner   = s"owner-${randomUUID().toString}"
+  val owner   = "transit-movements-router"
   val token   = s"token-${randomUUID().toString}"
   val config  = ObjectStoreClientConfig(baseUrl, owner, token, SevenYears)
 


### PR DESCRIPTION
I found that we need to add new internal auth token for to copy file to transit-movements-router/sdes location so added new internal auth for local testing.