### PR TITLE
CTCP-2949: Add ability to log EIS body when a 500 occurs

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/config/AppConfig.scala
@@ -47,6 +47,8 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: CTCServicesCon
   lazy val objectStoreUrl: String =
     config.get[String]("microservice.services.object-store.sdes-host")
 
+  lazy val logBodyOnEIS500: Boolean = config.get[Boolean]("microservice.services.eis.log-body-on-500")
+
   // SDES configuration
   lazy val sdesServiceBaseUrl          = Url.parse(servicesConfig.baseUrl("secure-data-exchange-proxy"))
   lazy val sdesInformationType: String = config.get[String]("sdes.information-type")

--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorProvider.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorProvider.scala
@@ -43,7 +43,10 @@ class EISConnectorProviderImpl @Inject() (
 )(implicit ec: ExecutionContext, mat: Materializer)
     extends EISConnectorProvider {
 
-  lazy val gb: EISConnector = new EISConnectorImpl("GB", appConfig.eisGb, appConfig.headerCarrierConfig, httpClientV2, retries, clock)
-  lazy val xi: EISConnector = new EISConnectorImpl("XI", appConfig.eisXi, appConfig.headerCarrierConfig, httpClientV2, retries, clock)
+  lazy val gb: EISConnector =
+    new EISConnectorImpl("GB", appConfig.eisGb, appConfig.headerCarrierConfig, httpClientV2, retries, clock, appConfig.logBodyOnEIS500)
+
+  lazy val xi: EISConnector =
+    new EISConnectorImpl("XI", appConfig.eisXi, appConfig.headerCarrierConfig, httpClientV2, retries, clock, appConfig.logBodyOnEIS500)
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,6 +137,7 @@ microservice {
     }
 
     eis {
+      log-body-on-500: true
       gb {
         protocol = http
         host = localhost

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
@@ -118,8 +118,8 @@ class EISConnectorSpec
   private val clock = Clock.fixed(OffsetDateTime.of(2023, 4, 13, 10, 34, 41, 500, ZoneOffset.UTC).toInstant, ZoneOffset.UTC)
 
   // We construct the connector each time to avoid issues with the circuit breaker
-  def noRetriesConnector = new EISConnectorImpl("NoRetry", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, NoRetries, clock)
-  def oneRetryConnector  = new EISConnectorImpl("OneRetry", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, OneRetry, clock)
+  def noRetriesConnector = new EISConnectorImpl("NoRetry", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, NoRetries, clock, true)
+  def oneRetryConnector  = new EISConnectorImpl("OneRetry", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, OneRetry, clock, true)
 
   lazy val connectorGen: Gen[() => EISConnector] = Gen.oneOf(() => noRetriesConnector, () => oneRetryConnector)
 
@@ -339,7 +339,7 @@ class EISConnectorSpec
       val httpClientV2 = mock[HttpClientV2]
 
       val hc        = HeaderCarrier()
-      val connector = new EISConnectorImpl("Failure", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, NoRetries, clock)
+      val connector = new EISConnectorImpl("Failure", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, NoRetries, clock, true)
 
       when(httpClientV2.post(ArgumentMatchers.any[URL])(ArgumentMatchers.any[HeaderCarrier])).thenReturn(new FakeRequestBuilder)
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorProviderSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorProviderSpec.scala
@@ -46,6 +46,7 @@ class EISConnectorProviderSpec extends AnyFreeSpec with HttpClientV2Support with
   val retries   = new RetriesImpl()
 
   override def beforeEach(): Unit = {
+    when(appConfig.logBodyOnEIS500).thenReturn(true)
     when(appConfig.eisGb).thenReturn(
       new EISInstanceConfig(
         "http",


### PR DESCRIPTION
We've come across an issue where what we expect to be a 4xx error on ERMIS to be mangled to a 500 by EIS. We want to be able to inspect errors from ERMIS so that we can potentially take action. We may need to turn this off on production, hence it's configurable