### PR TITLE
CTCP-2571: Allow the router to determine which route to send a message down, not the API

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/config/AppConfig.scala
@@ -48,6 +48,7 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: CTCServicesCon
     config.get[String]("microservice.services.object-store.sdes-host")
 
   lazy val logBodyOnEIS500: Boolean = config.get[Boolean]("microservice.services.eis.log-body-on-500")
+  lazy val eisSizeLimit: Long       = config.underlying.getMemorySize("microservice.services.eis.message-size-limit").toBytes
   lazy val logIncoming: Boolean     = config.get[Boolean]("log-incoming-errors")
 
   // SDES configuration

--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnector.scala
@@ -39,7 +39,7 @@ import uk.gov.hmrc.transitmovementsrouter.config.EISInstanceConfig
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MovementId
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError
 import uk.gov.hmrc.transitmovementsrouter.utils.RouterHeaderNames
 
 import java.time.Clock

--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnector.scala
@@ -30,8 +30,8 @@ import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.StringContextOps
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.transitmovementsrouter.models.errors.UpscanError
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
-import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnector.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.connectors
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import cats.data.EitherT
+import cats.implicits.toBifunctorOps
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import play.api.http.Status.NOT_FOUND
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.StringContextOps
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
+import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+@ImplementedBy(classOf[UpscanConnectorImpl])
+trait UpscanConnector {
+
+  def streamFile(url: DownloadUrl)(implicit hc: HeaderCarrier, mat: Materializer, ec: ExecutionContext): EitherT[Future, UpscanError, Source[ByteString, _]]
+
+}
+
+@Singleton
+class UpscanConnectorImpl @Inject() (httpClientV2: HttpClientV2) extends UpscanConnector {
+
+  override def streamFile(
+    url: DownloadUrl
+  )(implicit hc: HeaderCarrier, mat: Materializer, ec: ExecutionContext): EitherT[Future, UpscanError, Source[ByteString, _]] =
+    EitherT {
+      httpClientV2
+        .get(url"${url.value}")
+        .stream[Either[UpstreamErrorResponse, HttpResponse]]
+        .map {
+          _.map(_.bodyAsSource).leftMap {
+            case UpstreamErrorResponse(_, NOT_FOUND, _, _) => UpscanError.NotFound
+            case thr                                       => UpscanError.Unexpected(Some(thr))
+          }
+        }
+        .recover {
+          case NonFatal(thr) => Left(UpscanError.Unexpected(Some(thr)))
+        }
+    }
+
+}

--- a/app/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesController.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesController.scala
@@ -36,6 +36,7 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
 import uk.gov.hmrc.transitmovementsrouter.connectors.PersistenceConnector
 import uk.gov.hmrc.transitmovementsrouter.connectors.PushNotificationsConnector
+import uk.gov.hmrc.transitmovementsrouter.connectors.UpscanConnector
 import uk.gov.hmrc.transitmovementsrouter.controllers.actions.AuthenticateEISToken
 import uk.gov.hmrc.transitmovementsrouter.controllers.errors.ConvertError
 import uk.gov.hmrc.transitmovementsrouter.controllers.errors.PresentationError
@@ -48,9 +49,11 @@ import uk.gov.hmrc.transitmovementsrouter.models.sdes.SdesNotification
 import uk.gov.hmrc.transitmovementsrouter.models.sdes.SdesNotificationType
 import uk.gov.hmrc.transitmovementsrouter.services._
 import uk.gov.hmrc.transitmovementsrouter.utils.RouterHeaderNames
+import uk.gov.hmrc.transitmovementsrouter.utils.StreamWithFile
 
 import java.util.UUID
 import javax.inject.Inject
+import scala.annotation.unused
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -76,6 +79,7 @@ class MessagesController @Inject() (
   authenticateEISToken: AuthenticateEISToken,
   eisMessageTransformers: EISMessageTransformers,
   objectStoreService: ObjectStoreService,
+  upscanConnector: UpscanConnector,
   customOfficeExtractorService: CustomOfficeExtractorService,
   sdesService: SDESService,
   val config: AppConfig
@@ -89,63 +93,46 @@ class MessagesController @Inject() (
     with ObjectStoreURIExtractor
     with ContentTypeRouting
     with SdesResponseParser
-    with Logging {
+    with Logging
+    with StreamWithFile {
 
-  def outgoing(eori: EoriNumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[Source[ByteString, _]] =
-    contentTypeRoute {
-      case Some(_) => outgoingSmallMessage(eori, movementType, movementId, messageId)
-      case None    => outgoingLargeMessage(eori, movementType, movementId, messageId)
-    }
+  def outgoing(@unused eori: EoriNumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[Source[ByteString, _]] = {
+    def viaEIS(customsOffice: CustomsOffice, source: Source[ByteString, _])(implicit hc: HeaderCarrier): EitherT[Future, PresentationError, Status] =
+      for {
+        _ <- routingService.submitMessage(movementType, movementId, messageId, source, customsOffice).asPresentation
+      } yield Created
 
-  private def outgoingLargeMessage(eori: EoriNumber, movementType: MovementType, movementId: MovementId, messageId: MessageId) =
-    Action.async {
-      implicit request =>
-        implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
-        (for {
-          messageType                 <- messageTypeExtractor.extractFromHeaders(request.headers).asPresentation
-          requestMessageType          <- filterRequestMessageType(messageType)
-          objectStoreResourceLocation <- extractObjectStoreURIHeader(request.headers)
-          source                      <- objectStoreService.getObjectStoreFile(objectStoreResourceLocation).asPresentation
-          customOffice                <- customOfficeExtractorService.extractCustomOffice(source, requestMessageType).asPresentation
-          objectSummary <- objectStoreService
-            .storeOutgoing(objectStoreResourceLocation)
-            .asPresentation
-          result <- sdesService.send(movementId, messageId, objectSummary).asPresentation
-        } yield result).fold[Result](
-          error => Status(error.code.statusCode)(Json.toJson(error)),
-          _ => Accepted
-        )
-    }
+    def viaSDES(source: Source[ByteString, _])(implicit hc: HeaderCarrier): EitherT[Future, PresentationError, Status] =
+      for {
+        objectStoreFile <- objectStoreService.storeOutgoing(ConversationId(movementId, messageId), source).asPresentation
+        _               <- sdesService.send(movementId, messageId, objectStoreFile).asPresentation
+      } yield Accepted
 
-  private def outgoingSmallMessage(eori: EoriNumber, movementType: MovementType, movementId: MovementId, messageId: MessageId): Action[Source[ByteString, _]] =
     DefaultActionBuilder.apply(cc.parsers.anyContent).stream {
-      implicit request =>
-        implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+      implicit request => size =>
         (for {
           messageType        <- messageTypeExtractor.extractFromHeaders(request.headers).asPresentation
           requestMessageType <- filterRequestMessageType(messageType)
-          customOffice       <- customOfficeExtractorService.extractCustomOffice(request.body, requestMessageType).asPresentation
-          submitted          <- routingService.submitMessage(movementType, movementId, messageId, request.body, customOffice).asPresentation
-        } yield submitted).fold[Result](
-          error => Status(error.code.statusCode)(Json.toJson(error)),
-          _ => Accepted
+          customsOffice      <- customOfficeExtractorService.extractCustomOffice(request.body, requestMessageType).asPresentation
+          submitted          <- if (config.eisSizeLimit <= size) viaEIS(customsOffice, request.body) else viaSDES(request.body)
+        } yield submitted).valueOr(
+          error => Status(error.code.statusCode)(Json.toJson(error))
         )
     }
+  }
 
-  def incoming(ids: ConversationId): Action[Source[ByteString, _]] =
+  def incomingViaEIS(ids: ConversationId): Action[Source[ByteString, _]] =
     authenticateEISToken.stream(transformer = eisMessageTransformers.unwrap) {
-      implicit request =>
+      implicit request => _ =>
         import MessagesController.PresentationEitherTHelper
 
-        implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
-        val (movementId, triggerId)    = ids.toMovementAndMessageId
+        val (movementId, triggerId) = ids.toMovementAndMessageId
 
         (for {
           messageType <- messageTypeExtractor.extract(request.headers, request.body).asPresentationWithMessageType(None)
-          persistenceResponse <- persistenceConnector
-            .postBody(movementId, triggerId, messageType, request.body)
-            .asPresentationWithMessageType(Some(messageType))
-          _ = pushNotificationsConnector.postXML(movementId, persistenceResponse.messageId, request.body).asPresentation
+          persistenceResponse <- persistStream(movementId, triggerId, messageType, request.body).leftMap(
+            err => (err, Option(messageType))
+          )
           _ = logIncomingSuccess(movementId, triggerId, persistenceResponse.messageId, messageType)
         } yield persistenceResponse)
           .fold[Result](
@@ -164,28 +151,41 @@ class MessagesController @Inject() (
           )
     }
 
-  def incomingLargeMessage(movementId: MovementId, messageId: MessageId): Action[JsValue] = Action.async(cc.parsers.json) {
+  def incomingViaUpscan(movementId: MovementId, triggerId: MessageId): Action[JsValue] = Action.async(cc.parsers.json) {
     implicit request =>
       implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
       (for {
-        upscanResponse <- parseAndLogUpscanResponse(request.body)
-        downloadUrl    <- handleUpscanSuccessResponse(upscanResponse)
-        objectSummary <- objectStoreService
-          .storeIncoming(downloadUrl, movementId, messageId)
-          .asPresentation
-        objectStoreResourceLocation <- extractObjectStoreResourceLocation(ObjectStoreURI(objectSummary.location.asUri))
-        source                      <- objectStoreService.getObjectStoreFile(objectStoreResourceLocation).asPresentation
-        messageType                 <- messageTypeExtractor.extractFromBody(source).asPresentation
-        persistenceResponse <- persistenceConnector
-          .postObjectStoreUri(movementId, messageId, messageType, ObjectStoreURI(objectSummary.location.asUri))
-          .asPresentation
-        _ = pushNotificationsConnector.post(movementId, messageId).asPresentation
+        upscanResponse      <- parseAndLogUpscanResponse(request.body)
+        downloadUrl         <- handleUpscanSuccessResponse(upscanResponse)
+        source              <- upscanConnector.streamFile(downloadUrl).map(_.via(eisMessageTransformers.unwrap)).asPresentation
+        persistenceResponse <- withUpscanSource(movementId, triggerId, source)
       } yield persistenceResponse)
         .fold[Result](
           presentationError => Status(presentationError.code.statusCode)(Json.toJson(presentationError)),
           response => Created.withHeaders("X-Message-Id" -> response.messageId.value)
         )
   }
+
+  private def withUpscanSource(movementId: MovementId, triggerId: MessageId, source: Source[ByteString, _])(implicit
+    hc: HeaderCarrier
+  ): EitherT[Future, PresentationError, PersistenceResponse] =
+    withReusableSource(source) {
+      fileSource =>
+        for {
+          messageType         <- messageTypeExtractor.extractFromBody(fileSource).asPresentation
+          persistenceResponse <- persistStream(movementId, triggerId, messageType, fileSource)
+        } yield persistenceResponse
+    }
+
+  private def persistStream(movementId: MovementId, triggerId: MessageId, messageType: MessageType, source: Source[ByteString, _])(implicit
+    hc: HeaderCarrier
+  ): EitherT[Future, PresentationError, PersistenceResponse] =
+    for {
+      persistenceResponse <- persistenceConnector
+        .postBody(movementId, triggerId, messageType, source)
+        .asPresentation
+      _ = pushNotificationsConnector.postXML(movementId, persistenceResponse.messageId, source).asPresentation
+    } yield persistenceResponse
 
   private def handleUpscanSuccessResponse(upscanResponse: UpscanResponse): EitherT[Future, PresentationError, DownloadUrl] =
     EitherT {

--- a/app/uk/gov/hmrc/transitmovementsrouter/controllers/UpscanResponseParser.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/controllers/UpscanResponseParser.scala
@@ -21,7 +21,9 @@ import play.api.Logging
 import play.api.libs.json.JsValue
 import play.api.mvc.BaseController
 import uk.gov.hmrc.transitmovementsrouter.controllers.errors.PresentationError
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanFailedResponse
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanSuccessResponse
 
 import scala.concurrent.Future
 
@@ -45,11 +47,11 @@ trait UpscanResponseParser {
 
   private def logResponse(upscanResponse: Option[UpscanResponse]) =
     upscanResponse match {
-      case Some(UpscanResponse(_, reference, _, _, None)) =>
+      case Some(UpscanSuccessResponse(reference, _, _)) =>
         logger.info(s"Received a successful response from Upscan callback for the following reference: $reference")
-      case Some(UpscanResponse(_, reference, _, None, failureDetails)) =>
+      case Some(UpscanFailedResponse(reference, failureDetails)) =>
         logger.warn(
-          s"Received a failure response from Upscan callback for the following reference: $reference. Failure reason: ${failureDetails.get.failureReason}. Failure message: ${failureDetails.get.message}"
+          s"Received a failure response from Upscan callback for the following reference: $reference. Failure reason: ${failureDetails.failureReason}. Failure message: ${failureDetails.message}"
         )
       case _ => logger.error("Unable to parse unexpected response from Upscan")
     }

--- a/app/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertError.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.transitmovementsrouter.models.errors.CustomOfficeExtractorErr
 import uk.gov.hmrc.transitmovementsrouter.models.errors.CustomOfficeExtractorError.UnrecognisedOffice
 import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
 import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError._
+import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -111,6 +112,16 @@ trait ConvertError {
 
     def convert(error: SDESError): PresentationError = error match {
       case UnexpectedError(thr) => PresentationError.internalServiceError(cause = thr)
+    }
+  }
+
+  implicit val upscanErrorConverter = new Converter[UpscanError] {
+
+    import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError._
+
+    def convert(error: UpscanError): PresentationError = error match {
+      case NotFound        => PresentationError.notFoundError("Upscan returned a not found error for the provided URL")
+      case Unexpected(thr) => PresentationError.internalServiceError(cause = thr)
     }
   }
 

--- a/app/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertError.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertError.scala
@@ -26,9 +26,9 @@ import uk.gov.hmrc.transitmovementsrouter.models.errors.SDESError
 import uk.gov.hmrc.transitmovementsrouter.models.errors.CustomOfficeExtractorError.NoElementFound
 import uk.gov.hmrc.transitmovementsrouter.models.errors.CustomOfficeExtractorError.TooManyElementsFound
 import uk.gov.hmrc.transitmovementsrouter.models.errors.CustomOfficeExtractorError.UnrecognisedOffice
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError._
-import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError._
+import uk.gov.hmrc.transitmovementsrouter.models.errors.UpscanError
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -116,7 +116,7 @@ trait ConvertError {
 
   implicit val upscanErrorConverter = new Converter[UpscanError] {
 
-    import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError._
+    import uk.gov.hmrc.transitmovementsrouter.models.errors.UpscanError._
 
     def convert(error: UpscanError): PresentationError = error match {
       case NotFound        => PresentationError.notFoundError("Upscan returned a not found error for the provided URL")

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/errors/RoutingError.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/errors/RoutingError.scala
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.transitmovementsrouter.services.error
+package uk.gov.hmrc.transitmovementsrouter.models.errors
 
-sealed trait UpscanError
+import uk.gov.hmrc.http.UpstreamErrorResponse
 
-object UpscanError {
-  final case class Unexpected(cause: Option[Throwable]) extends UpscanError
-  final case object NotFound                            extends UpscanError
+import java.time.format.DateTimeParseException
+
+object RoutingError {
+  case class Upstream(upstreamErrorResponse: UpstreamErrorResponse)          extends RoutingError
+  case class Unexpected(message: String, cause: Option[Throwable])           extends RoutingError
+  case class BadDateTime(element: String, exception: DateTimeParseException) extends RoutingError
 }
+
+sealed trait RoutingError

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/errors/UpscanError.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/errors/UpscanError.scala
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.transitmovementsrouter.services.error
+package uk.gov.hmrc.transitmovementsrouter.models.errors
 
-import uk.gov.hmrc.http.UpstreamErrorResponse
+sealed trait UpscanError
 
-import java.time.format.DateTimeParseException
-
-object RoutingError {
-  case class Upstream(upstreamErrorResponse: UpstreamErrorResponse)          extends RoutingError
-  case class Unexpected(message: String, cause: Option[Throwable])           extends RoutingError
-  case class BadDateTime(element: String, exception: DateTimeParseException) extends RoutingError
+object UpscanError {
+  final case class Unexpected(cause: Option[Throwable]) extends UpscanError
+  final case object NotFound                            extends UpscanError
 }
-
-sealed trait RoutingError

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/RoutingService.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/RoutingService.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.transitmovementsrouter.connectors.EISConnector
 import uk.gov.hmrc.transitmovementsrouter.connectors.EISConnectorProvider
 import uk.gov.hmrc.transitmovementsrouter.models._
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/error/UpscanError.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/error/UpscanError.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.services.error
+
+sealed trait UpscanError
+
+object UpscanError {
+  final case class Unexpected(cause: Option[Throwable]) extends UpscanError
+  final case object NotFound                            extends UpscanError
+}

--- a/app/uk/gov/hmrc/transitmovementsrouter/utils/StreamWithFile.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/utils/StreamWithFile.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.utils
+
+import akka.stream.IOResult
+import akka.stream.Materializer
+import akka.stream.scaladsl.FileIO
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import cats.data.EitherT
+import cats.syntax.flatMap._
+import play.api.Logging
+import play.api.libs.Files.TemporaryFileCreator
+import uk.gov.hmrc.transitmovementsrouter.controllers.errors.PresentationError
+
+import java.nio.file.Path
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+trait StreamWithFile {
+  self: Logging =>
+
+  def withReusableSource[R](
+    src: Source[ByteString, _]
+  )(
+    block: Source[ByteString, _] => EitherT[Future, PresentationError, R]
+  )(implicit temporaryFileCreator: TemporaryFileCreator, mat: Materializer, ec: ExecutionContext): EitherT[Future, PresentationError, R] = {
+    val file = temporaryFileCreator.create()
+    (for {
+      _      <- writeToFile(file, src)
+      result <- block(FileIO.fromPath(file))
+    } yield result)
+      .flatTap {
+        _ =>
+          file.delete()
+          EitherT.rightT(())
+      }
+
+  }
+
+  private def writeToFile(file: Path, src: Source[ByteString, _])(implicit
+    mat: Materializer,
+    ec: ExecutionContext
+  ): EitherT[Future, PresentationError, IOResult] =
+    EitherT(
+      src
+        .runWith(FileIO.toPath(file))
+        .map(Right.apply)
+        .recover {
+          case NonFatal(thr) =>
+            logger.error(s"Failed to create file stream: $thr", thr)
+            Left(PresentationError.internalServiceError(cause = Some(thr)))
+        }
+    )
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,8 +2,8 @@
 
 POST        /traders/:eori/movements/:movementType/:movementId/messages/:messageId             uk.gov.hmrc.transitmovementsrouter.controllers.MessagesController.outgoing(eori: EoriNumber, movementType: MovementType, movementId: MovementId, messageId: MessageId)
 
-POST        /movements/:movementId/messages/:messageId                                         uk.gov.hmrc.transitmovementsrouter.controllers.MessagesController.incomingLargeMessage(movementId: MovementId, messageId: MessageId)
+POST        /movements/:movementId/messages/:messageId                                         uk.gov.hmrc.transitmovementsrouter.controllers.MessagesController.incomingViaUpscan(movementId: MovementId, messageId: MessageId)
 
-POST        /movements/:ids/messages                                                           uk.gov.hmrc.transitmovementsrouter.controllers.MessagesController.incoming(ids: ConversationId)
+POST        /movements/:ids/messages                                                           uk.gov.hmrc.transitmovementsrouter.controllers.MessagesController.incomingViaEIS(ids: ConversationId)
 
 POST        /sdes/callback                                                          uk.gov.hmrc.transitmovementsrouter.controllers.MessagesController.handleSdesResponse()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -138,6 +138,7 @@ microservice {
 
     eis {
       log-body-on-500: true
+      message-size-limit = 5M
       gb {
         protocol = http
         host = localhost

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
@@ -52,7 +52,7 @@ import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MovementId
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError
 
 import java.net.URL
 import java.time.Clock

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/PushNotificationConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/PushNotificationConnectorSpec.scala
@@ -38,7 +38,6 @@ import play.api.http.HeaderNames
 import play.api.http.Status.ACCEPTED
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.http.Status.NOT_FOUND
-import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.http.HeaderCarrier

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnectorSpec.scala
@@ -1,0 +1,90 @@
+package uk.gov.hmrc.transitmovementsrouter.connectors
+
+import akka.stream.scaladsl.Sink
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import org.scalacheck.Gen
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.NOT_FOUND
+import play.api.http.Status.OK
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.test.HttpClientV2Support
+import uk.gov.hmrc.transitmovementsrouter.it.base.TestActorSystem
+import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
+import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UpscanConnectorSpec
+    extends AnyFreeSpec
+    with Matchers
+    with WiremockSuite
+    with TestActorSystem
+    with HttpClientV2Support
+    with ScalaFutures
+    with ScalaCheckDrivenPropertyChecks {
+
+  "streamFile" - {
+
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    "gets a stream when the file exists" in forAll(Gen.alphaNumStr) {
+      string =>
+        server.stubFor(
+          get("/test.xml")
+            .willReturn(aResponse().withStatus(OK).withBody(string))
+        )
+
+        val sut = new UpscanConnectorImpl(httpClientV2)
+        val result = sut
+          .streamFile(DownloadUrl(s"http://localhost:${server.port()}/test.xml"))
+          .semiflatMap(
+            stream => stream.reduce(_ ++ _).map(_.utf8String).runWith(Sink.head[String])
+          )
+
+        whenReady(result.value) {
+          case Right(result) => result mustBe string
+          case a             => fail(s"Expected Right($string), got $a")
+        }
+    }
+
+    "returns a NotFound error when the file does not exist" in {
+      server.stubFor(
+        get("/test.xml")
+          .willReturn(aResponse().withStatus(NOT_FOUND))
+      )
+
+      val sut = new UpscanConnectorImpl(httpClientV2)
+      val result = sut
+        .streamFile(DownloadUrl(s"http://localhost:${server.port()}/test.xml"))
+
+      whenReady(result.value) {
+        case Left(UpscanError.NotFound) => succeed
+        case a                          => fail(s"Expected Left(NotFound), got $a")
+      }
+    }
+
+    "returns a Unexpected error when a 500 is returned" in {
+      server.stubFor(
+        get("/test.xml")
+          .willReturn(aResponse().withStatus(INTERNAL_SERVER_ERROR))
+      )
+
+      val sut = new UpscanConnectorImpl(httpClientV2)
+      val result = sut
+        .streamFile(DownloadUrl(s"http://localhost:${server.port()}/test.xml"))
+
+      whenReady(result.value) {
+        case Left(UpscanError.Unexpected(_)) => succeed
+        case a                               => fail(s"Expected Left(Unexpected), got $a")
+      }
+    }
+
+  }
+
+}

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/UpscanConnectorSpec.scala
@@ -34,8 +34,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.test.HttpClientV2Support
 import uk.gov.hmrc.transitmovementsrouter.it.base.TestActorSystem
 import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.models.errors.UpscanError
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
-import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/it/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
@@ -381,7 +381,7 @@ class MessagesControllerIntegrationSpec
 
           running(newApp) {
             val sut    = newApp.injector.instanceOf[MessagesController]
-            val result = sut.incoming(conversationId)(eisRequest)
+            val result = sut.incomingViaEIS(conversationId)(eisRequest)
 
             Helpers.status(result) mustBe CREATED
           }
@@ -406,7 +406,7 @@ class MessagesControllerIntegrationSpec
 
       running(newApp) {
         val sut    = newApp.injector.instanceOf[MessagesController]
-        val result = sut.incoming(conversationId)(eisRequest)
+        val result = sut.incomingViaEIS(conversationId)(eisRequest)
 
         Helpers.status(result) mustBe BAD_REQUEST
       }
@@ -430,7 +430,7 @@ class MessagesControllerIntegrationSpec
 
         running(app) {
           val sut    = app.injector.instanceOf[MessagesController]
-          val result = sut.incoming(conversationId)(eisRequest)
+          val result = sut.incomingViaEIS(conversationId)(eisRequest)
 
           Helpers.status(result) mustBe UNAUTHORIZED
         }

--- a/it/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
@@ -21,6 +21,7 @@ import akka.util.ByteString
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.equalToXml
 import com.github.tomakehurst.wiremock.client.WireMock.matching
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
@@ -121,6 +122,16 @@ class MessagesControllerIntegrationSpec
       </CustomsOfficeOfDeparture>
     </ncts:CC015C>.mkString
 
+  val sampleOutgoingXmlWrapped: String =
+    <n1:TraderChannelRequest xmlns:txd="http://ncts.dgtaxud.ec" xmlns:n1="http://www.hmrc.gov.uk/eis/ncts5/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hmrc.gov.uk/eis/ncts5/v1 EIS_WrapperV11_TraderChannelRequest-51.8.xsd">
+      <txd:CC015C PhaseID="NCTS5.0">
+        <preparationDateAndTime>2022-05-25T09:37:04</preparationDateAndTime>
+        <CustomsOfficeOfDeparture>
+          <referenceNumber>GB1234567</referenceNumber>
+        </CustomsOfficeOfDeparture>
+      </txd:CC015C>
+    </n1:TraderChannelRequest>.mkString
+
   val sampleOutgoingLargeXml: String =
     <ncts:CC015C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec">
       <preparationDateAndTime>2022-05-25T09:37:04</preparationDateAndTime>
@@ -132,6 +143,19 @@ class MessagesControllerIntegrationSpec
       </something>
     </ncts:CC015C>.mkString
 
+  val sampleOutgoingLargeXmlWrapped: String =
+    <n1:TraderChannelRequest xmlns:txd="http://ncts.dgtaxud.ec" xmlns:n1="http://www.hmrc.gov.uk/eis/ncts5/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hmrc.gov.uk/eis/ncts5/v1 EIS_WrapperV11_TraderChannelRequest-51.8.xsd">
+      <txd:CC015C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec">
+        <preparationDateAndTime>2022-05-25T09:37:04</preparationDateAndTime>
+        <CustomsOfficeOfDeparture>
+          <referenceNumber>GB1234567</referenceNumber>
+        </CustomsOfficeOfDeparture>
+        <something>
+          <somethingElse>test</somethingElse>
+        </something>
+      </txd:CC015C>
+    </n1:TraderChannelRequest>.mkString
+
   val sampleOutgoingLargeXmlSize: Long = ByteString(sampleOutgoingLargeXml).size - 1
 
   val sampleOutgoingXIXml: String =
@@ -141,6 +165,16 @@ class MessagesControllerIntegrationSpec
         <referenceNumber>XI1234567</referenceNumber>
       </CustomsOfficeOfDeparture>
     </ncts:CC015C>.mkString
+
+  val sampleOutgoingXIXmlWrapped: String =
+    <n1:TraderChannelRequest xmlns:txd="http://ncts.dgtaxud.ec" xmlns:n1="http://www.hmrc.gov.uk/eis/ncts5/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hmrc.gov.uk/eis/ncts5/v1 EIS_WrapperV11_TraderChannelRequest-51.8.xsd">
+      <txd:CC015C PhaseID="NCTS5.0">
+        <preparationDateAndTime>2022-05-25T09:37:04</preparationDateAndTime>
+        <CustomsOfficeOfDeparture>
+          <referenceNumber>XI1234567</referenceNumber>
+        </CustomsOfficeOfDeparture>
+      </txd:CC015C>
+    </n1:TraderChannelRequest>.mkString
 
   val brokenXml: String =
     """<nope>
@@ -226,6 +260,7 @@ class MessagesControllerIntegrationSpec
             .withHeader("X-Conversation-Id", equalTo(conversationId.value.toString))
             .withHeader(HeaderNames.ACCEPT, equalTo("application/xml"))
             .withHeader(HeaderNames.CONTENT_TYPE, equalTo("application/xml"))
+            .withRequestBody(equalToXml(sampleOutgoingXmlWrapped))
             .willReturn(aResponse().withStatus(OK))
         )
 
@@ -261,7 +296,6 @@ class MessagesControllerIntegrationSpec
         val time      = OffsetDateTime.of(2023, 2, 14, 15, 55, 28, 0, ZoneOffset.UTC)
         val formatted = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH).withZone(ZoneOffset.UTC).format(time)
 
-        // should not happen
         server.stubFor(
           post(
             urlEqualTo("/xi")
@@ -272,6 +306,7 @@ class MessagesControllerIntegrationSpec
             .withHeader("X-Conversation-Id", equalTo(conversationId.value.toString))
             .withHeader(HeaderNames.ACCEPT, equalTo("application/xml"))
             .withHeader(HeaderNames.CONTENT_TYPE, equalTo("application/xml"))
+            .withRequestBody(equalToXml(sampleOutgoingXIXmlWrapped))
             .willReturn(aResponse().withStatus(OK))
         )
 
@@ -315,6 +350,7 @@ class MessagesControllerIntegrationSpec
             .withHeader("X-Conversation-Id", equalTo(conversationId.value.toString))
             .withHeader(HeaderNames.ACCEPT, equalTo("application/xml"))
             .withHeader(HeaderNames.CONTENT_TYPE, equalTo("application/xml"))
+            .withRequestBody(equalToXml(sampleOutgoingXmlWrapped))
             .willReturn(aResponse().withStatus(FORBIDDEN))
         )
 

--- a/it/uk/gov/hmrc/transitmovementsrouter/generators/BaseGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/generators/BaseGenerators.scala
@@ -20,7 +20,6 @@ import cats.data.NonEmptyList
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalacheck.Gen.alphaNumChar
 import org.scalacheck.Gen.choose
 import org.scalacheck.Gen.listOfN
 import org.scalacheck.Gen.numChar
@@ -41,10 +40,5 @@ trait BaseGenerators {
       length        <- choose(minLength, maxLength)
       listOfCharNum <- listOfN(length, numChar)
     } yield listOfCharNum.mkString.toInt
-
-  def alphaNumeric(length: Int): Gen[String] =
-    for {
-      listOfChar <- listOfN(length, alphaNumChar)
-    } yield listOfChar.mkString
 
 }

--- a/test/uk/gov/hmrc/transitmovementsrouter/controllers/MessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/controllers/MessageControllerSpec.scala
@@ -23,8 +23,10 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoSugar.reset
 import org.mockito.MockitoSugar.when
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
@@ -33,11 +35,13 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.Logger
 import play.api.http.DefaultHttpErrorHandler
 import play.api.http.HeaderNames
 import play.api.http.HttpErrorConfig
 import play.api.http.MimeTypes
 import play.api.http.Status._
+import play.api.libs.Files
 import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
@@ -54,6 +58,7 @@ import uk.gov.hmrc.http.HttpVerbs.POST
 import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
 import uk.gov.hmrc.transitmovementsrouter.base.StreamTestHelpers.createStream
 import uk.gov.hmrc.transitmovementsrouter.base.TestActorSystem
+import uk.gov.hmrc.transitmovementsrouter.base.TestSourceProvider
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
 import uk.gov.hmrc.transitmovementsrouter.connectors.PersistenceConnector
 import uk.gov.hmrc.transitmovementsrouter.connectors.PushNotificationsConnector
@@ -68,7 +73,9 @@ import uk.gov.hmrc.transitmovementsrouter.models.errors.PersistenceError.Movemen
 import uk.gov.hmrc.transitmovementsrouter.models.errors.PersistenceError.Unexpected
 import uk.gov.hmrc.transitmovementsrouter.models.errors._
 import uk.gov.hmrc.transitmovementsrouter.models.requests.MessageUpdate
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanSuccessResponse
 import uk.gov.hmrc.transitmovementsrouter.models.sdes.SdesNotificationType
 import uk.gov.hmrc.transitmovementsrouter.services._
 import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
@@ -86,12 +93,13 @@ class MessageControllerSpec
     with BeforeAndAfterEach
     with ScalaCheckDrivenPropertyChecks
     with TestModelGenerators
+    with TestSourceProvider
     with ScalaFutures {
 
-  val eori         = EoriNumber("eori")
-  val movementType = MovementType("departures")
-  val movementId   = MovementId("abcdef1234567890")
-  val messageId    = MessageId("0987654321fedcba")
+  val eori: EoriNumber           = EoriNumber("eori")
+  val movementType: MovementType = MovementType("departures")
+  val movementId: MovementId     = MovementId("abcdef1234567890")
+  val messageId: MessageId       = MessageId("0987654321fedcba")
 
   val cc015cOfficeOfDepartureGB: NodeSeq =
     <ncts:CC015C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec">
@@ -107,21 +115,23 @@ class MessageControllerSpec
     </TraderChannelResponse>
   val trimmedXml: NodeSeq = <ncts:CC013C PhaseID="NCTS5.0" xmlns:ncts="http://ncts.dgtaxud.ec">text</ncts:CC013C>
 
-  val mockRoutingService               = mock[RoutingService]
-  val mockPersistenceConnector         = mock[PersistenceConnector]
-  val mockPushNotificationsConnector   = mock[PushNotificationsConnector]
-  val mockUpscanResponseParser         = mock[UpscanResponseParser]
-  val mockObjectStoreService           = mock[ObjectStoreService]
-  val mockObjectStoreURIExtractor      = mock[ObjectStoreURIExtractor]
-  val mockCustomOfficeExtractorService = mock[CustomOfficeExtractorService]
-  val mockSDESService                  = mock[SDESService]
-  val mockSdesResponseParser           = mock[SdesResponseParser]
-  val mockUpscanConnector              = mock[UpscanConnector]
+  val mockRoutingService: RoutingService                             = mock[RoutingService]
+  val mockPersistenceConnector: PersistenceConnector                 = mock[PersistenceConnector]
+  val mockPushNotificationsConnector: PushNotificationsConnector     = mock[PushNotificationsConnector]
+  val mockUpscanResponseParser: UpscanResponseParser                 = mock[UpscanResponseParser]
+  val mockObjectStoreService: ObjectStoreService                     = mock[ObjectStoreService]
+  val mockObjectStoreURIExtractor: ObjectStoreURIExtractor           = mock[ObjectStoreURIExtractor]
+  val mockCustomOfficeExtractorService: CustomOfficeExtractorService = mock[CustomOfficeExtractorService]
+  val mockSDESService: SDESService                                   = mock[SDESService]
+  val mockSdesResponseParser: SdesResponseParser                     = mock[SdesResponseParser]
+  val mockUpscanConnector: UpscanConnector                           = mock[UpscanConnector]
 
-  implicit val temporaryFileCreator = SingletonTemporaryFileCreator
+  implicit val temporaryFileCreator: Files.SingletonTemporaryFileCreator.type = SingletonTemporaryFileCreator
 
-  val errorHandler                    = new DefaultHttpErrorHandler(HttpErrorConfig(showDevErrors = false, None), None, None)
-  val controllerComponentWithTempFile = stubControllerComponents(playBodyParsers = PlayBodyParsers(SingletonTemporaryFileCreator, errorHandler)(materializer))
+  val errorHandler = new DefaultHttpErrorHandler(HttpErrorConfig(showDevErrors = false, None), None, None)
+
+  val controllerComponentWithTempFile: ControllerComponents =
+    stubControllerComponents(playBodyParsers = PlayBodyParsers(SingletonTemporaryFileCreator, errorHandler)(materializer))
 
   object FakeAuthenticateEISToken extends AuthenticateEISToken {
     override protected def filter[A](request: Request[A]): Future[Option[Result]] = Future.successful(None)
@@ -133,10 +143,8 @@ class MessageControllerSpec
 
   val mockMessageTypeExtractor: MessageTypeExtractor = mock[MessageTypeExtractor]
   val config: AppConfig                              = mock[AppConfig]
-  when(config.logIncoming).thenReturn(true)
-  when(config.eisSizeLimit).thenReturn(5000000) // 5MB, TODO: we'll need to vary this per test
 
-  def controller(eisMessageTransformer: EISMessageTransformers = new FakeXmlTransformer(trimmedXml)) =
+  def controller(eisMessageTransformer: EISMessageTransformers = new FakeXmlTransformer(trimmedXml)): MessagesController =
     new MessagesController(
       controllerComponentWithTempFile,
       mockRoutingService,
@@ -150,16 +158,19 @@ class MessageControllerSpec
       mockCustomOfficeExtractorService,
       mockSDESService,
       config
-    )
+    ) {
+      // suppress logging
+      override protected val logger: Logger = mock[Logger]
+    }
 
-  def source = createStream(cc015cOfficeOfDepartureGB)
+  def source: Source[ByteString, _] = createStream(cc015cOfficeOfDepartureGB)
 
-  val outgoing             = routes.MessagesController.outgoing(eori, movementType, movementId, messageId).url
-  val incoming             = routes.MessagesController.incomingViaEIS(ConversationId(movementId, messageId)).url
-  val incomingLargeMessage = routes.MessagesController.incomingViaUpscan(movementId, messageId).url
-  val sdesCallback         = routes.MessagesController.handleSdesResponse().url
+  val outgoing: String             = routes.MessagesController.outgoing(eori, movementType, movementId, messageId).url
+  val incoming: String             = routes.MessagesController.incomingViaEIS(ConversationId(movementId, messageId)).url
+  val incomingLargeMessage: String = routes.MessagesController.incomingViaUpscan(movementId, messageId).url
+  val sdesCallback: String         = routes.MessagesController.handleSdesResponse().url
 
-  def fakeRequest[A](
+  def fakeRequest(
     body: NodeSeq,
     url: String,
     headers: FakeHeaders = FakeHeaders(Seq.empty)
@@ -171,7 +182,7 @@ class MessageControllerSpec
       body = createStream(body)
     )
 
-  def fakeRequestLargeMessage[A](
+  def fakeRequestLargeMessage(
     body: JsValue,
     url: String
   ): Request[JsValue] =
@@ -182,7 +193,7 @@ class MessageControllerSpec
       body = body
     )
 
-  override def afterEach(): Unit = {
+  override def beforeEach(): Unit = {
     reset(mockRoutingService)
     reset(mockMessageTypeExtractor)
     reset(mockPersistenceConnector)
@@ -191,16 +202,19 @@ class MessageControllerSpec
     reset(mockSDESService)
     reset(mockPushNotificationsConnector)
     reset(mockUpscanConnector)
+    reset(config)
+    when(config.logIncoming).thenReturn(true)
+    when(config.eisSizeLimit).thenReturn(5000000) // TODO: vary per test
     super.afterEach()
   }
 
   lazy val submitDeclarationEither: EitherT[Future, RoutingError, Unit] =
     EitherT.rightT(())
 
-  lazy val messageTypeHeader = FakeHeaders(Seq(("X-Message-Type", MessageType.DeclarationData.code)))
+  lazy val messageTypeHeader: FakeHeaders = FakeHeaders(Seq(("X-Message-Type", MessageType.DeclarationData.code)))
 
   "POST outgoing" - {
-    "must return ACCEPTED when declaration is submitted successfully" in {
+    "must return CREATED when declaration is submitted successfully via the EIS route" in {
 
       when(
         mockRoutingService.submitMessage(
@@ -212,14 +226,6 @@ class MessageControllerSpec
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(submitDeclarationEither)
 
-      when(
-        mockPushNotificationsConnector
-          .postXML(any[String].asInstanceOf[MovementId], any[String].asInstanceOf[MessageId], any[Source[ByteString, _]])(
-            any[HeaderCarrier],
-            any[ExecutionContext]
-          )
-      ).thenReturn(EitherT.rightT(()))
-
       when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
 
       when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
@@ -227,7 +233,46 @@ class MessageControllerSpec
 
       val result = controller().outgoing(eori, movementType, movementId, messageId)(fakeRequest(cc015cOfficeOfDepartureGB, outgoing, messageTypeHeader))
 
-      status(result) mustBe ACCEPTED
+      status(result) mustBe CREATED
+    }
+
+    "must return ACCEPTED when declaration is submitted successfully via the SDES route" in forAll(
+      arbitrary[EoriNumber],
+      arbitrary[MovementType],
+      arbitrary[MovementId],
+      arbitrary[MessageId],
+      arbitrary[ObjectSummaryWithMd5]
+    ) {
+      (eori, movementType, movementId, messageId, summary) =>
+        val expectedConversationId = ConversationId(movementId, messageId)
+
+        when(config.eisSizeLimit).thenReturn(-1)
+
+        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
+
+        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
+          .thenReturn(EitherT.rightT[Future, CustomOfficeExtractorError](CustomsOffice("GB1234567")))
+
+        when(
+          mockObjectStoreService
+            .storeOutgoing(ConversationId(eqTo(expectedConversationId.value)), any[Source[ByteString, _]])(any[HeaderCarrier], any[ExecutionContext])
+        )
+          .thenReturn(EitherT.rightT(summary))
+
+        when(mockSDESService.send(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), eqTo(summary))(any(), any()))
+          .thenReturn(EitherT.rightT((): Unit))
+
+        val result = controller().outgoing(eori, movementType, movementId, messageId)(fakeRequest(cc015cOfficeOfDepartureGB, outgoing, messageTypeHeader))
+
+        status(result) mustBe ACCEPTED
+
+        verify(mockRoutingService, times(0)).submitMessage(
+          any[String].asInstanceOf[MovementType],
+          any[String].asInstanceOf[MovementId],
+          any[String].asInstanceOf[MessageId],
+          any[Source[ByteString, _]],
+          any[String].asInstanceOf[CustomsOffice]
+        )(any[HeaderCarrier], any[ExecutionContext])
     }
 
     "must return BAD_REQUEST when declaration submission fails" - {
@@ -366,414 +411,28 @@ class MessageControllerSpec
 
   }
 
-  "POST outgoing Large message" - {
-    "must return ACCEPTED when declaration is submitted successfully" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
+  "POST incoming from EIS" - {
+    "must return CREATED when message is successfully forwarded" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType]) {
+      (movementId, messageId, messageType) =>
+        when(mockMessageTypeExtractor.extract(any(), any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](messageType))
 
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(source))
-
-        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
-          .thenReturn(EitherT.rightT[Future, CustomOfficeExtractorError](CustomsOffice("GB1234567")))
+        when(mockPersistenceConnector.postBody(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), eqTo(messageType), any())(any(), any()))
+          .thenReturn(EitherT.fromEither(Right(PersistenceResponse(messageId))))
 
         when(
-          mockObjectStoreService.storeOutgoing(
-            any[String].asInstanceOf[ObjectStoreResourceLocation]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
-
-        when(
-          mockSDESService.send(
-            eqTo(MovementId(movementId.value)),
-            eqTo(MessageId(messageId.value)),
-            eqTo(ObjectSummaryWithMd5(objectSummary.location, objectSummary.contentLength, objectSummary.contentMd5, objectSummary.lastModified))
-          )(any[ExecutionContext], any[HeaderCarrier])
+          mockPushNotificationsConnector
+            .postXML(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Source[ByteString, _]])(
+              any[HeaderCarrier],
+              any[ExecutionContext]
+            )
         ).thenReturn(EitherT.rightT(()))
+        val request = fakeRequest(incomingXml, incoming)
+          .withHeaders(FakeHeaders().add("X-Message-Type" -> RequestOfRelease.code))
 
-        lazy val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
+        val result = controller().incomingViaEIS(ConversationId(movementId, messageId))(request)
 
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe ACCEPTED
-    }
-
-    "must return message to inform that the X-Message-Type header is not present" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any()))
-          .thenReturn(EitherT.leftT[Future, MessageType](MessageTypeExtractionError.UnableToExtractFromHeader))
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "Missing header: X-Message-Type"
-        )
-    }
-
-    "must return message to inform that the X-Message-Type header value is invalid" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any()))
-          .thenReturn(EitherT.leftT[Future, MessageType](MessageTypeExtractionError.InvalidMessageType("EEinvalid")))
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "Invalid message type: EEinvalid"
-        )
-    }
-
-    "must return BAD_REQUEST when a message is not a request message" in {
-
-      when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.Discrepancies))
-
-      val request = FakeRequest(
-        method = "POST",
-        uri = outgoing,
-        headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.Discrepancies.code)),
-        body = AnyContentAsEmpty
-      )
-      val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-      status(result) mustBe BAD_REQUEST
-      contentAsJson(result) mustBe Json.obj(
-        "code"    -> "BAD_REQUEST",
-        "message" -> s"${MessageType.Discrepancies.code} is not valid for requests"
-      )
-    }
-
-    "must return message to inform that the X-Object-Store-Uri header is not present" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary
-    ) {
-      (movementId, messageId) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.leftT(PresentationError.badRequestError("Missing X-Object-Store-Uri header value")))
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code)),
-          body = AnyContentAsEmpty
-        )
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "Missing X-Object-Store-Uri header value"
-        )
-    }
-
-    "must return BAD_REQUEST when file not found on object store resource location" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.leftT(ObjectStoreError.FileNotFound(objectStoreResourceLocation.contextPath)))
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> s"file not found at location: ${objectStoreResourceLocation.contextPath}"
-        )
-    }
-
-    "must return INVALID_OFFICE when an invalid custom office supplied in payload" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary,
-      Gen.alphaNumStr,
-      Gen.alphaStr
-    ) {
-      (movementId, messageId, objectStoreResourceLocation, office, field) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(source))
-
-        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
-          .thenReturn(
-            EitherT[Future, CustomOfficeExtractorError, CustomsOffice](
-              Future.successful(Left(CustomOfficeExtractorError.UnrecognisedOffice("office", CustomsOffice(office), field)))
-            )
-          )
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "INVALID_OFFICE",
-          "message" -> "office",
-          "office"  -> office,
-          "field"   -> field
-        )
-    }
-
-    "must return message to indicate element not found" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(source))
-
-        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
-          .thenReturn(
-            EitherT[Future, CustomOfficeExtractorError, CustomsOffice](Future.successful(Left(CustomOfficeExtractorError.NoElementFound("messageSender"))))
-          )
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "Element messageSender not found"
-        )
-    }
-
-    "must return message to indicate too many elements" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(source))
-
-        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
-          .thenReturn(
-            EitherT[Future, CustomOfficeExtractorError, CustomsOffice](Future.successful(Left(CustomOfficeExtractorError.TooManyElementsFound("eori"))))
-          )
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> "Found too many elements of type eori"
-        )
-    }
-
-    "must return INTERNAL_SERVER_ERROR when declaration submission fails due to unexpected error" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectStoreResourceLocation) =>
-        when(mockMessageTypeExtractor.extractFromHeaders(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-        when(mockObjectStoreURIExtractor.extractObjectStoreURIHeader(any[Headers]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(source))
-
-        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), any()))
-          .thenReturn(EitherT.rightT[Future, CustomOfficeExtractorError](CustomsOffice("GB1234567")))
-
-        when(
-          mockObjectStoreService.storeOutgoing(
-            any[String].asInstanceOf[ObjectStoreResourceLocation]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.leftT(ObjectStoreError.UnexpectedError(None)))
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe INTERNAL_SERVER_ERROR
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "INTERNAL_SERVER_ERROR",
-          "message" -> "Internal server error"
-        )
-    }
-
-    "must return INTERNAL_SERVER_ERROR when submission fails to SDES due to unexpected error" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockMessageTypeExtractor.extractFromHeaders(
-            eqTo(FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)))
-          )
-        ).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-        when(
-          mockObjectStoreURIExtractor.extractObjectStoreURIHeader(
-            eqTo(FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)))
-          )
-        )
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(
-          mockObjectStoreService.getObjectStoreFile(
-            eqTo(
-              ObjectStoreResourceLocation(
-                objectStoreResourceLocation.contextPath,
-                objectStoreResourceLocation.resourceLocation
-              )
-            )
-          )(any[HeaderCarrier], any[ExecutionContext])
-        )
-          .thenReturn(EitherT.rightT(source))
-
-        when(mockCustomOfficeExtractorService.extractCustomOffice(any(), eqTo(MessageType.DeclarationData)))
-          .thenReturn(EitherT.rightT[Future, CustomOfficeExtractorError](CustomsOffice("GB1234567")))
-
-        when(
-          mockObjectStoreService.storeOutgoing(
-            eqTo(ObjectStoreResourceLocation(objectStoreResourceLocation.contextPath, objectStoreResourceLocation.resourceLocation))
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
-
-        when(
-          mockSDESService.send(
-            eqTo(MovementId(movementId.value)),
-            eqTo(MessageId(messageId.value)),
-            eqTo(ObjectSummaryWithMd5(objectSummary.location, objectSummary.contentLength, objectSummary.contentMd5, objectSummary.lastModified))
-          )(any[ExecutionContext], any[HeaderCarrier])
-        ).thenReturn(
-          EitherT.leftT(SDESError.UnexpectedError(None))
-        )
-
-        val request = FakeRequest(
-          method = "POST",
-          uri = outgoing,
-          headers = FakeHeaders(Seq("X-Message-Type" -> MessageType.DeclarationData.code, "X-Object-Store-Uri" -> objectStoreResourceLocation.contextPath)),
-          body = AnyContentAsEmpty
-        )
-
-        val result = controller().outgoing(eori, movementType, movementId, messageId)(request)
-
-        status(result) mustBe INTERNAL_SERVER_ERROR
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "INTERNAL_SERVER_ERROR",
-          "message" -> "Internal server error"
-        )
-    }
-
-  }
-
-  "POST incoming" - {
-    "must return CREATED when message is successfully forwarded" in {
-      when(mockPersistenceConnector.postBody(any[String].asInstanceOf[MovementId], any[String].asInstanceOf[MessageId], any(), any())(any(), any()))
-        .thenReturn(EitherT.fromEither(Right(PersistenceResponse(MessageId("1")))))
-      when(mockMessageTypeExtractor.extract(any(), any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.RequestOfRelease))
-      when(
-        mockPushNotificationsConnector
-          .postXML(any[String].asInstanceOf[MovementId], any[String].asInstanceOf[MessageId], any[Source[ByteString, _]])(
-            any[HeaderCarrier],
-            any[ExecutionContext]
-          )
-      ).thenReturn(EitherT.rightT(()))
-      val request = fakeRequest(incomingXml, incoming)
-        .withHeaders(FakeHeaders().add("X-Message-Type" -> RequestOfRelease.code))
-
-      val result = controller().incomingViaEIS(ConversationId(movementId, messageId))(request)
-
-      status(result) mustBe CREATED
-      header("X-Message-Id", result) mustBe Some("1")
+        status(result) mustBe CREATED
+        header("X-Message-Id", result) mustBe Some(messageId.value)
     }
 
     "must return BAD_REQUEST when the X-Message-Type header is missing or body seems to not contain an appropriate root tag" in {
@@ -827,53 +486,35 @@ class MessageControllerSpec
 
   }
 
-  "POST incoming for Large message" - {
+  "POST incoming from Upscan" - {
 
     "must return CREATED when message is successfully forwarded" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
+      arbitrary[UpscanSuccessResponse],
       arbitraryMovementId.arbitrary,
       arbitraryMessageId.arbitrary,
       arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
+      arbitrary[MessageType]
     ) {
-      (successUpscanResponse, movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
+      (successUpscanResponse, movementId, messageId, objectSummary, messageType) =>
+        val source: Source[ByteString, _] = singleUseStringSource("abc")
 
-        when(mockObjectStoreURIExtractor.extractObjectStoreResourceLocation(any[String].asInstanceOf[ObjectStoreURI]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
+        when(mockUpscanConnector.streamFile(DownloadUrl(eqTo(successUpscanResponse.downloadUrl.value)))(any(), any(), any()))
+          .thenReturn(EitherT.rightT(source))
 
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(Source.single(ByteString("this is test content"))))
+        when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](messageType))
 
-        when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-
-        when(
-          mockPersistenceConnector.postObjectStoreUri(
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId],
-            any[String].asInstanceOf[MessageType],
-            any[String].asInstanceOf[ObjectStoreURI]
-          )(any(), any())
-        ).thenReturn(EitherT.fromEither(Right(PersistenceResponse(messageId))))
+        when(mockPersistenceConnector.postBody(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), eqTo(messageType), any())(any(), any()))
+          .thenReturn(EitherT.fromEither(Right(PersistenceResponse(messageId))))
 
         when(
           mockPushNotificationsConnector
-            .post(any[String].asInstanceOf[MovementId], any[String].asInstanceOf[MessageId])(
+            .postXML(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), any[Source[ByteString, _]])(
               any(),
               any()
             )
         ).thenReturn(EitherT.rightT(()))
 
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
+        val request = fakeRequestLargeMessage(Json.toJson[UpscanResponse](successUpscanResponse), incomingLargeMessage)
 
         val result = controller().incomingViaUpscan(movementId, messageId)(request)
 
@@ -882,45 +523,29 @@ class MessageControllerSpec
     }
 
     "must return NOT_FOUND when target movement is invalid or archived" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
+      arbitrary[UpscanSuccessResponse],
       arbitraryMovementId.arbitrary,
       arbitraryMessageId.arbitrary,
       arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
+      arbitrary[MessageType]
     ) {
-      (successUpscanResponse, movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
+      (successUpscanResponse, movementId, messageId, objectSummary, messageType) =>
+        val source: Source[ByteString, _] = singleUseStringSource("abc")
 
-        when(mockObjectStoreURIExtractor.extractObjectStoreResourceLocation(any[String].asInstanceOf[ObjectStoreURI]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
+        when(mockUpscanConnector.streamFile(DownloadUrl(eqTo(successUpscanResponse.downloadUrl.value)))(any(), any(), any()))
+          .thenReturn(EitherT.rightT(source))
 
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(Source.single(ByteString("this is test content"))))
+        when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](messageType))
 
-        when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
+        when(mockPersistenceConnector.postBody(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), eqTo(messageType), any())(any(), any()))
+          .thenReturn(EitherT.fromEither(Left(MovementNotFound(movementId))))
 
-        when(
-          mockPersistenceConnector.postObjectStoreUri(
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId],
-            any[String].asInstanceOf[MessageType],
-            any[String].asInstanceOf[ObjectStoreURI]
-          )(any(), any())
-        ).thenReturn(EitherT.fromEither(Left(MovementNotFound(MovementId("ABC")))))
-
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
+        val request = fakeRequestLargeMessage(Json.toJson[UpscanResponse](successUpscanResponse), incomingLargeMessage)
         val result  = controller().incomingViaUpscan(movementId, messageId)(request)
 
         status(result) mustBe NOT_FOUND
+
+        verifyNoInteractions(mockPushNotificationsConnector)
     }
 
     "must return BAD_REQUEST when malformed json received from callback" in forAll(
@@ -939,175 +564,82 @@ class MessageControllerSpec
         val result  = controller().incomingViaUpscan(movementId, messageId)(request)
 
         status(result) mustBe BAD_REQUEST
-    }
-
-    "must return INTERNAL_SERVER_ERROR when uploading to object-store fails" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary
-    ) {
-      (successUpscanResponse, movementId, messageId) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.leftT(ObjectStoreError.UnexpectedError(None)))
-
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
-
-        val result = controller().incomingViaUpscan(movementId, messageId)(request)
-
-        status(result) mustBe INTERNAL_SERVER_ERROR
+        verifyNoInteractions(mockUpscanConnector)
+        verifyNoInteractions(mockMessageTypeExtractor)
+        verifyNoInteractions(mockPersistenceConnector)
+        verifyNoInteractions(mockPushNotificationsConnector)
     }
 
     "must return BAD_REQUEST when body seems to not contain an appropriate root tag" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
+      arbitrary[UpscanSuccessResponse],
       arbitraryMovementId.arbitrary,
       arbitraryMessageId.arbitrary,
-      arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
+      arbitraryObjectSummaryWithMd5.arbitrary
     ) {
-      (successUpscanResponse, movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
+      (successUpscanResponse, movementId, messageId, objectSummary) =>
+        val source: Source[ByteString, _] = singleUseStringSource("abc")
 
-        when(mockObjectStoreURIExtractor.extractObjectStoreResourceLocation(any[String].asInstanceOf[ObjectStoreURI]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(Source.single(ByteString("this is test content"))))
+        when(mockUpscanConnector.streamFile(DownloadUrl(eqTo(successUpscanResponse.downloadUrl.value)))(any(), any(), any()))
+          .thenReturn(EitherT.rightT(source))
 
         when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.leftT[Future, MessageType](MessageTypeExtractionError.UnableToExtractFromBody))
 
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
+        val request = fakeRequestLargeMessage(Json.toJson[UpscanResponse](successUpscanResponse), incomingLargeMessage)
         val result  = controller().incomingViaUpscan(movementId, messageId)(request)
 
         status(result) mustBe BAD_REQUEST
+
+        verifyNoInteractions(mockPersistenceConnector)
+        verifyNoInteractions(mockPushNotificationsConnector)
     }
 
     "must return BAD_REQUEST when message type is invalid" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
+      arbitrary[UpscanSuccessResponse],
       arbitraryMovementId.arbitrary,
       arbitraryMessageId.arbitrary,
-      arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
+      arbitraryObjectSummaryWithMd5.arbitrary
     ) {
-      (successUpscanResponse, movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
+      (successUpscanResponse, movementId, messageId, objectSummary) =>
+        val source: Source[ByteString, _] = singleUseStringSource("abc")
 
-        when(mockObjectStoreURIExtractor.extractObjectStoreResourceLocation(any[String].asInstanceOf[ObjectStoreURI]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(Source.single(ByteString("this is test content"))))
+        when(mockUpscanConnector.streamFile(DownloadUrl(eqTo(successUpscanResponse.downloadUrl.value)))(any(), any(), any()))
+          .thenReturn(EitherT.rightT(source))
 
         when(mockMessageTypeExtractor.extractFromBody(any()))
           .thenReturn(EitherT.leftT[Future, MessageType](MessageTypeExtractionError.InvalidMessageType("abcde")))
 
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
+        val request = fakeRequestLargeMessage(Json.toJson[UpscanResponse](successUpscanResponse), incomingLargeMessage)
         val result  = controller().incomingViaUpscan(movementId, messageId)(request)
 
         status(result) mustBe BAD_REQUEST
+
+        verifyNoInteractions(mockPersistenceConnector)
+        verifyNoInteractions(mockPushNotificationsConnector)
     }
 
-    "must return BAD_REQUEST when file not found on object store resource location" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
+    "must return INTERNAL_SERVER_ERROR when persistence service fails unexpectedly" in forAll(
+      arbitrary[UpscanSuccessResponse],
       arbitraryMovementId.arbitrary,
       arbitraryMessageId.arbitrary,
-      arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
+      arbitrary[MessageType]
     ) {
-      (successUpscanResponse, movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
+      (successUpscanResponse, movementId, messageId, messageType) =>
+        val source: Source[ByteString, _] = singleUseStringSource("abc")
 
-        when(mockObjectStoreURIExtractor.extractObjectStoreResourceLocation(any[String].asInstanceOf[ObjectStoreURI]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
+        when(mockUpscanConnector.streamFile(DownloadUrl(eqTo(successUpscanResponse.downloadUrl.value)))(any(), any(), any()))
+          .thenReturn(EitherT.rightT(source))
 
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.leftT(ObjectStoreError.FileNotFound(objectStoreResourceLocation.contextPath)))
+        when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](messageType))
 
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
-        val result  = controller().incomingViaUpscan(movementId, messageId)(request)
-
-        status(result) mustBe BAD_REQUEST
-        contentAsJson(result) mustBe Json.obj(
-          "code"    -> "BAD_REQUEST",
-          "message" -> s"file not found at location: ${objectStoreResourceLocation.contextPath}"
-        )
-    }
-
-    "must return INTERNAL_SERVER_ERROR when persistence service fails unexpected" in forAll(
-      arbitraryUpscanResponse(true).arbitrary,
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary,
-      arbitraryObjectSummaryWithMd5.arbitrary,
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      (successUpscanResponse, movementId, messageId, objectSummary, objectStoreResourceLocation) =>
-        when(
-          mockObjectStoreService.storeIncoming(
-            any[String].asInstanceOf[DownloadUrl],
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId]
-          )(
-            any(),
-            any()
-          )
-        ).thenReturn(EitherT.rightT(objectSummary))
-
-        when(mockObjectStoreURIExtractor.extractObjectStoreResourceLocation(any[String].asInstanceOf[ObjectStoreURI]))
-          .thenReturn(EitherT.rightT(objectStoreResourceLocation))
-
-        when(mockObjectStoreService.getObjectStoreFile(any[String].asInstanceOf[ObjectStoreResourceLocation])(any[HeaderCarrier], any[ExecutionContext]))
-          .thenReturn(EitherT.rightT(Source.single(ByteString("this is test content"))))
-
-        when(mockMessageTypeExtractor.extractFromBody(any())).thenReturn(EitherT.rightT[Future, MessageTypeExtractionError](MessageType.DeclarationData))
-
-        when(
-          mockPersistenceConnector.postObjectStoreUri(
-            any[String].asInstanceOf[MovementId],
-            any[String].asInstanceOf[MessageId],
-            any[String].asInstanceOf[MessageType],
-            any[String].asInstanceOf[ObjectStoreURI]
-          )(any(), any())
-        )
+        when(mockPersistenceConnector.postBody(MovementId(eqTo(movementId.value)), MessageId(eqTo(messageId.value)), eqTo(messageType), any())(any(), any()))
           .thenReturn(EitherT.fromEither(Left(Unexpected(None))))
 
-        val request = fakeRequestLargeMessage(Json.toJson(successUpscanResponse), incomingLargeMessage)
+        val request = fakeRequestLargeMessage(Json.toJson[UpscanResponse](successUpscanResponse), incomingLargeMessage)
         val result  = controller().incomingViaUpscan(movementId, messageId)(request)
 
         status(result) mustBe INTERNAL_SERVER_ERROR
+
+        verifyNoInteractions(mockPushNotificationsConnector)
     }
   }
 
@@ -1232,6 +764,7 @@ class MessageControllerSpec
       val messageStatus = sdesResponse.notification match {
         case SdesNotificationType.FileProcessed         => MessageStatus.Success
         case SdesNotificationType.FileProcessingFailure => MessageStatus.Failed
+        case x                                          => fail(s"Notification type $x was not expected")
       }
 
       when(

--- a/test/uk/gov/hmrc/transitmovementsrouter/controllers/UpscanResponseParserSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/controllers/UpscanResponseParserSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.transitmovementsrouter.controllers
 
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -27,6 +28,9 @@ import play.api.mvc.ControllerComponents
 import play.api.test.Helpers.stubControllerComponents
 import uk.gov.hmrc.transitmovementsrouter.controllers.errors.PresentationError
 import uk.gov.hmrc.transitmovementsrouter.generators.TestModelGenerators
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanFailedResponse
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanSuccessResponse
 
 class UpscanResponseParserSpec extends AnyFreeSpec with ScalaFutures with Matchers with ScalaCheckPropertyChecks with TestModelGenerators {
 
@@ -38,28 +42,24 @@ class UpscanResponseParserSpec extends AnyFreeSpec with ScalaFutures with Matche
 
   "parseUpscanResponse" - {
     "given a successful response in the callback, returns a defined option with value of UploadDetails" in forAll(
-      arbitraryUpscanResponse(true).arbitrary
+      arbitrary[UpscanSuccessResponse]
     ) {
       successUpscanResponse =>
-        val json = Json.toJson(successUpscanResponse)
+        val json = Json.toJson[UpscanResponse](successUpscanResponse)
         whenReady(testController.parseAndLogUpscanResponse(json).value) {
           either =>
             either mustBe Right(successUpscanResponse)
-            either.toOption.get.isSuccess mustBe true
-            either.toOption.get.uploadDetails.isDefined mustBe true
         }
     }
 
     "given a failure response in the callback, returns a defined option with value of FailedDetails" in forAll(
-      arbitraryUpscanResponse(false).arbitrary
+      arbitrary[UpscanFailedResponse]
     ) {
       failureUpscanResponse =>
-        val json = Json.toJson(failureUpscanResponse)
+        val json = Json.toJson[UpscanResponse](failureUpscanResponse)
         whenReady(testController.parseAndLogUpscanResponse(json).value) {
           either =>
             either mustBe Right(failureUpscanResponse)
-            either.toOption.get.isSuccess mustBe false
-            either.toOption.get.failureDetails.isDefined mustBe true
         }
     }
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertErrorSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertErrorSpec.scala
@@ -43,9 +43,9 @@ import uk.gov.hmrc.transitmovementsrouter.models.errors.ObjectStoreError
 import uk.gov.hmrc.transitmovementsrouter.models.errors.PersistenceError
 import uk.gov.hmrc.transitmovementsrouter.models.errors.PushNotificationError
 import uk.gov.hmrc.transitmovementsrouter.models.errors.SDESError
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
-import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError._
-import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError
+import uk.gov.hmrc.transitmovementsrouter.models.errors.RoutingError._
+import uk.gov.hmrc.transitmovementsrouter.models.errors.UpscanError
 
 import java.time.format.DateTimeParseException
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertErrorSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/controllers/errors/ConvertErrorSpec.scala
@@ -45,6 +45,7 @@ import uk.gov.hmrc.transitmovementsrouter.models.errors.PushNotificationError
 import uk.gov.hmrc.transitmovementsrouter.models.errors.SDESError
 import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError
 import uk.gov.hmrc.transitmovementsrouter.services.error.RoutingError._
+import uk.gov.hmrc.transitmovementsrouter.services.error.UpscanError
 
 import java.time.format.DateTimeParseException
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -238,6 +239,33 @@ class ConvertErrorSpec extends AnyFreeSpec with Matchers with OptionValues with 
       val input = Left[SDESError, Unit](SDESError.UnexpectedError(None)).toEitherT[Future]
       whenReady(input.asPresentation.value) {
         _ mustBe Left(InternalServiceError("Internal server error", InternalServerError, None))
+
+      }
+    }
+  }
+
+  "UpscanError" - {
+
+    "an UnexpectedError Error with exception returns an internal service error with an exception" in {
+      val exception = new IllegalStateException()
+      val input     = Left[UpscanError, Unit](UpscanError.Unexpected(Some(exception))).toEitherT[Future]
+      whenReady(input.asPresentation.value) {
+        _ mustBe Left(InternalServiceError("Internal server error", InternalServerError, Some(exception)))
+      }
+    }
+
+    "an UnexpectedError Error with no exception returns an internal service error with no exception" in {
+      val input = Left[UpscanError, Unit](UpscanError.Unexpected(None)).toEitherT[Future]
+      whenReady(input.asPresentation.value) {
+        _ mustBe Left(InternalServiceError("Internal server error", InternalServerError, None))
+
+      }
+    }
+
+    "a NotFound returns a not found" in {
+      val input = Left[UpscanError, Unit](UpscanError.NotFound).toEitherT[Future]
+      whenReady(input.asPresentation.value) {
+        _ mustBe Left(StandardError("Upscan returned a not found error for the provided URL", NotFound))
 
       }
     }

--- a/test/uk/gov/hmrc/transitmovementsrouter/controllers/stream/StreamingParsersSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/controllers/stream/StreamingParsersSpec.scala
@@ -61,7 +61,7 @@ import scala.concurrent.Future
 
 class StreamingParsersSpec extends AnyFreeSpec with Matchers with TestActorSystem with TestSourceProvider {
 
-  lazy val headers = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> "text/plain", HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json"))
+  lazy val headers: FakeHeaders = FakeHeaders(Seq(HeaderNames.CONTENT_TYPE -> "text/plain", HeaderNames.ACCEPT -> "application/vnd.hmrc.2.0+json"))
 
   object TestActionBuilder extends ActionRefiner[Request, Request] with ActionBuilder[Request, AnyContent] {
 
@@ -89,7 +89,7 @@ class StreamingParsersSpec extends AnyFreeSpec with Matchers with TestActorSyste
     }
 
     def resultStream: Action[Source[ByteString, _]] = Action.andThen(TestActionBuilder).stream {
-      request =>
+      request => _ =>
         (for {
           a <- request.body.runWith(Sink.last)
           b <- request.body.runWith(Sink.last)
@@ -106,7 +106,7 @@ class StreamingParsersSpec extends AnyFreeSpec with Matchers with TestActorSyste
           a => a ++ a
         )
       ) {
-        request =>
+        request => _ =>
           (for {
             a <- request.body.runWith(Sink.last)
             b <- request.body.runWith(Sink.last)
@@ -123,7 +123,7 @@ class StreamingParsersSpec extends AnyFreeSpec with Matchers with TestActorSyste
           _ => throw new IllegalStateException("this happened")
         )
       ) {
-        _ =>
+        _ => _ =>
           Future.successful(Ok("but should never happen"))
       }
 
@@ -134,7 +134,7 @@ class StreamingParsersSpec extends AnyFreeSpec with Matchers with TestActorSyste
           _ => throw new NumberFormatException() // doesn't matter - we're just not expecting it
         )
       ) {
-        _ =>
+        _ => _ =>
           Future.successful(Ok("but should never happen"))
       }
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/generators/TestModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/generators/TestModelGenerators.scala
@@ -53,12 +53,20 @@ trait TestModelGenerators extends BaseGenerators {
 
   implicit lazy val arbitraryMovementId: Arbitrary[MovementId] =
     Arbitrary {
-      Gen.listOfN(16, Gen.hexChar).map(_.mkString).map(MovementId)
+      Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase).map(MovementId)
     }
 
   implicit lazy val arbitraryMessageId: Arbitrary[MessageId] =
     Arbitrary {
-      Gen.listOfN(16, Gen.hexChar).map(_.mkString).map(MessageId)
+      Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase).map(MessageId)
+    }
+
+  implicit lazy val arbitraryConversationId: Arbitrary[ConversationId] =
+    Arbitrary {
+      for {
+        movementId <- arbitraryMovementId.arbitrary
+        messageId  <- arbitraryMessageId.arbitrary
+      } yield ConversationId(movementId, messageId)
     }
 
   implicit lazy val arbitraryMessageType: Arbitrary[MessageType] =

--- a/test/uk/gov/hmrc/transitmovementsrouter/generators/TestModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/generators/TestModelGenerators.scala
@@ -61,7 +61,7 @@ trait TestModelGenerators extends BaseGenerators {
 
   implicit lazy val arbitraryMovementType: Arbitrary[MovementType] =
     Arbitrary {
-      Gen.oneOf(MovementType("departure"), MovementType("arrival"))
+      Gen.oneOf(MovementType("departures"), MovementType("arrivals"))
     }
 
   implicit lazy val arbitraryMovementId: Arbitrary[MovementId] =

--- a/test/uk/gov/hmrc/transitmovementsrouter/models/UpscanResponseSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/models/UpscanResponseSpec.scala
@@ -21,11 +21,19 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.libs.json.JsSuccess
 import play.api.libs.json.Json
+import uk.gov.hmrc.transitmovementsrouter.models.responses.FailureDetails
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UploadDetails
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanFailedResponse
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.Reference
+import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanSuccessResponse
+
+import java.time.OffsetDateTime
 
 class UpscanResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
-  "SuccessfulSubmission" - {
+  "Successful submission response" - {
     "deserializes correctly" in {
       val jsonSuccessResponse = Json.obj(
         "reference"   -> "11370e18-6e24-453e-b45a-76d3e32ea33d",
@@ -41,13 +49,40 @@ class UpscanResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDriven
       )
 
       jsonSuccessResponse.validate[UpscanResponse] match {
-        case JsSuccess(response, _) => response.isSuccess mustBe true
-        case _                      => fail("Expected to be a success response from upscan")
+        case JsSuccess(x: UpscanSuccessResponse, _) => succeed
+        case _                                      => fail("Expected to be a success response from upscan")
       }
+    }
+
+    "serializes correctly" in {
+      val response = UpscanSuccessResponse(
+        Reference("11370e18-6e24-453e-b45a-76d3e32ea33d"),
+        DownloadUrl("https://bucketName.s3.eu-west-2.amazonaws.com?1235676"),
+        UploadDetails(
+          "test.pdf",
+          "application/pdf",
+          OffsetDateTime.parse("2018-04-24T09:30:00Z").toInstant,
+          "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+          987
+        )
+      )
+
+      Json.toJson[UpscanResponse](response) mustBe Json.obj(
+        "reference"   -> "11370e18-6e24-453e-b45a-76d3e32ea33d",
+        "downloadUrl" -> "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
+        "fileStatus"  -> "READY",
+        "uploadDetails" -> Json.obj(
+          "fileName"        -> "test.pdf",
+          "fileMimeType"    -> "application/pdf",
+          "uploadTimestamp" -> "2018-04-24T09:30:00Z",
+          "checksum"        -> "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+          "size"            -> 987
+        )
+      )
     }
   }
 
-  "SubmissionFailure" - {
+  "Failed submission response" - {
     val jsonFailureResponse = Json.obj(
       "reference"  -> "11370e18-6e24-453e-b45a-76d3e32ea33d",
       "fileStatus" -> "FAILED",
@@ -58,9 +93,21 @@ class UpscanResponseSpec extends AnyFreeSpec with Matchers with ScalaCheckDriven
     )
     "deserializes correctly" in {
       jsonFailureResponse.validate[UpscanResponse] match {
-        case JsSuccess(response, _) => response.isSuccess mustBe false
-        case _                      => fail("Expected to be a failure response from upscan")
+        case JsSuccess(x: UpscanFailedResponse, _) => succeed
+        case _                                     => fail("Expected to be a failure response from upscan")
       }
+    }
+
+    "serializes correctly" in {
+      val upscanFailureResponse = UpscanFailedResponse(
+        Reference("11370e18-6e24-453e-b45a-76d3e32ea33d"),
+        FailureDetails(
+          "QUARANTINE",
+          "This file has a virus"
+        )
+      )
+
+      Json.toJson[UpscanResponse](upscanFailureResponse) mustBe jsonFailureResponse
     }
   }
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreServiceSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.transitmovementsrouter.services
 
-import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.mockito.ArgumentMatchers.any
@@ -51,9 +50,7 @@ import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
 import uk.gov.hmrc.transitmovementsrouter.fakes.objectstore.ObjectStoreStub
 import uk.gov.hmrc.transitmovementsrouter.generators.TestModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
-import uk.gov.hmrc.transitmovementsrouter.models.ObjectStoreResourceLocation
 import uk.gov.hmrc.transitmovementsrouter.models.errors.ObjectStoreError
-import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
 
 import java.time.Clock
 import java.time.LocalDateTime
@@ -85,74 +82,6 @@ class ObjectStoreServiceSpec
 
   override def beforeEach(): Unit =
     reset(objectStoreStub)
-
-  "On adding incoming message to object store" - {
-    "given a successful response from the connector, should return a Right with Object Store Summary" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary
-    ) {
-      (movementId, messageId) =>
-        val result = objectStoreService.storeIncoming(
-          DownloadUrl("https://bucketName.s3.eu-west-2.amazonaws.com"),
-          movementId,
-          messageId
-        )
-
-        whenReady(result.value, timeout(Span(6, Seconds))) {
-          case Left(e)  => fail(e.toString)
-          case Right(x) => x
-        }
-    }
-
-    "given an exception is thrown in the service, should return a Left with the exception in an ObjectStoreError" in forAll(
-      arbitraryMovementId.arbitrary,
-      arbitraryMessageId.arbitrary
-    ) {
-      (movementId, messageId) =>
-        val result = objectStoreService.storeIncoming(
-          DownloadUrl("invalidURL"),
-          movementId,
-          messageId
-        )
-
-        whenReady(result.value) {
-          case Right(_) => fail("should have returned a Left")
-          case Left(x)  => x
-        }
-    }
-  }
-
-  "On adding outgoing message to object store via copy" - {
-    "given a successful response from the connector, should return a Right with Object Store Summary" in forAll(
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      objectStoreResourceLocation =>
-        when(appConfig.objectStoreUrl).thenReturn("http://localhost:8084/object-store/object")
-        val result = objectStoreService.storeOutgoing(
-          objectStoreResourceLocation
-        )
-
-        whenReady(result.value, timeout(Span(6, Seconds))) {
-          case Left(e)  => fail(e.toString)
-          case Right(x) => x
-        }
-    }
-
-    "given an exception is thrown in the service, should return a Left with the exception in an ObjectStoreError" in forAll(
-      arbitraryObjectStoreResourceLocation.arbitrary
-    ) {
-      objectStoreResourceLocation =>
-        when(appConfig.objectStoreUrl).thenReturn("invalid")
-        val result = objectStoreService.storeOutgoing(
-          objectStoreResourceLocation
-        )
-
-        whenReady(result.value) {
-          case Right(_) => fail("should have returned a Left")
-          case Left(x)  => x
-        }
-    }
-  }
 
   "storeOutgoing (via stream)" - {
     "given a successful response from the connector, should return a Right with Object Store Summary" in forAll(
@@ -246,45 +175,6 @@ class ObjectStoreServiceSpec
           case x => fail(s"Expected Left of unexpected error, instead got $x")
         }
     }
-  }
-
-  "get file from  object store" - {
-    "should return the contents of a file" in {
-      val filePath =
-        Path.Directory("movements/movementId").file("x-conversation-id.xml").asUri
-      val result = objectStoreService.getObjectStoreFile(ObjectStoreResourceLocation("", filePath))
-
-      whenReady(result.value) {
-        r =>
-          r.isRight mustBe true
-          r.toOption.get.runWith(Sink.head).futureValue.utf8String mustBe "content"
-      }
-    }
-
-    "should return an error when the file is not found on path" in {
-      val filePath =
-        Path.Directory("abc/movementId").file("x-conversation-id.xml").asUri
-      val result = objectStoreService.getObjectStoreFile(ObjectStoreResourceLocation("", filePath))
-
-      whenReady(result.value, timeout(Span(6, Seconds))) {
-        case Left(_: ObjectStoreError.FileNotFound) => succeed
-        case x =>
-          fail(s"Expected Left(ObjectStoreError.FileNotFound), instead got $x")
-      }
-    }
-
-    "on a failed submission, should return a Left with an UnexpectedError" in {
-      val filePath =
-        Path.File("x-conversation-id.xml").asUri
-      val result = objectStoreService.getObjectStoreFile(ObjectStoreResourceLocation("", filePath))
-
-      whenReady(result.value, timeout(Span(6, Seconds))) {
-        case Left(_: ObjectStoreError.UnexpectedError) => succeed
-        case x =>
-          fail(s"Expected Left(ObjectStoreError.UnexpectedError), instead got $x")
-      }
-    }
-
   }
 
 }

--- a/test/uk/gov/hmrc/transitmovementsrouter/utils/StreamWithFileSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/utils/StreamWithFileSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.utils
+
+import akka.stream.scaladsl.Sink
+import cats.data.EitherT
+import org.scalacheck.Gen
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.Logging
+import play.api.libs.Files
+import play.api.libs.Files.SingletonTemporaryFileCreator
+import play.api.libs.Files.TemporaryFileCreator
+import uk.gov.hmrc.transitmovementsrouter.base.TestActorSystem
+import uk.gov.hmrc.transitmovementsrouter.base.TestSourceProvider
+import uk.gov.hmrc.transitmovementsrouter.controllers.errors.PresentationError
+
+import java.nio.file.Path
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.io.Source
+import scala.util.Success
+import scala.util.Try
+
+class StreamWithFileSpec
+    extends AnyFreeSpec
+    with TestActorSystem
+    with Matchers
+    with TestSourceProvider
+    with ScalaCheckDrivenPropertyChecks
+    with OptionValues
+    with ScalaFutures {
+
+  case class DummyTemporaryFileCreator(temporaryFile: Files.TemporaryFile) extends TemporaryFileCreator {
+
+    override def create(prefix: String, suffix: String): Files.TemporaryFile = temporaryFile
+
+    override def create(path: Path): Files.TemporaryFile = temporaryFile
+
+    override def delete(file: Files.TemporaryFile): Try[Boolean] = Success(true)
+  }
+
+  "withReusableSource" - {
+    object Harness extends StreamWithFile with Logging
+
+    "using a reusable source on a single use source should create a file when streamed once" in {
+
+      // create the file now so we can check it later.
+      implicit val temporaryFileCreator: DummyTemporaryFileCreator = DummyTemporaryFileCreator(SingletonTemporaryFileCreator.create())
+      temporaryFileCreator.temporaryFile.deleteOnExit()
+
+      val string = Gen.stringOfN(10, Gen.alphaNumChar).sample.value
+      val source = singleUseStringSource(string)
+
+      Harness.withReusableSource(source) {
+        source =>
+          EitherT[Future, PresentationError, Unit] {
+            source
+              .runWith(Sink.ignore)
+              .map {
+                _ =>
+                  // we now load the file and it should contain the string
+                  val fileContents = Source.fromFile(temporaryFileCreator.temporaryFile.toFile)
+                  try fileContents.mkString mustBe string
+                  finally fileContents.close()
+                  Right(()) // this simply fulfils the contract
+              }
+          }
+      }
+    }
+
+    "using a reusable source on a single use source can be used multiple times in succession and get the same result" in {
+
+      // create the file now so we can check it later.
+      implicit val temporaryFileCreator: DummyTemporaryFileCreator = DummyTemporaryFileCreator(SingletonTemporaryFileCreator.create())
+      temporaryFileCreator.temporaryFile.deleteOnExit()
+
+      val string = Gen.stringOfN(10, Gen.alphaNumChar).sample.value
+      val source = singleUseStringSource(string)
+
+      Harness.withReusableSource(source) {
+        source =>
+          val future = for {
+            first  <- source.runWith(Sink.head).map(_.utf8String)
+            second <- source.runWith(Sink.head).map(_.utf8String)
+            third  <- source.runWith(Sink.head).map(_.utf8String)
+            fourth <- source.runWith(Sink.head).map(_.utf8String)
+          } yield (first, second, third, fourth)
+
+          whenReady(future) {
+            result =>
+              result._1 mustBe string
+              result._2 mustBe string
+              result._3 mustBe string
+              result._4 mustBe string
+          }
+
+          EitherT.rightT[Future, PresentationError](())
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Part 4a of centralising object-store access.

## What is this PR?

This PR moves EIS/SDES route decision logic to the router and removes access to `common-transit-convention-traders` object store locations (but leaves the `transit-movements-router` one in tact.

## Why?

PlatOps asked us to not access object-store from outside the storing service. This PR implements that (mostly), along with the `common-transit-convention-traders` PR at https://github.com/hmrc/common-transit-convention-traders/pull/418, which must be merged at the same time.

##  What changes are there?

* Whether we submit to SDES or EIS is now decided by the router, not by the API layer, and the returned status code (201 or 202) will tell us how it was submitted so we can act accordingly 
* We no longer accept object store URIs, instead requiring streams
* We will now pass streams to `transit-movements` and not access `object-store` for messages that come in via EIS or SDES.
* Renamed `incoming` and `incomingLargeMessage` to `incomingViaEIS` and `incomingViaUpscan` for easier readability
* Don't log exceptions when XML/Json fails to parse

Regression tests all pass!

## What's next?

Once this is in and working, we'll change the owner in `transit-movements` from `common-transit-convention-traders` to `transit-movements`, and fix `internal-auth-config` to match this.