### PR TITLE
CTCP-3363: Revert "Strip the message ID from the conversation ID to work around backend issue"

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnector.scala
@@ -143,7 +143,7 @@ class EISConnectorImpl(
       val requestId      = hc.requestId.map(_.value)
       val correlationId  = UUID.randomUUID().toString
       val accept         = MimeTypes.XML
-      val conversationId = ConversationId(movementId, MessageId("0000000000000000")) // ConversationId(movementId, messageId)
+      val conversationId = ConversationId(movementId, messageId)
       val date           = HTTP_DATE_FORMATTER.format(OffsetDateTime.now())
 
       val messageType =
@@ -164,15 +164,12 @@ class EISConnectorImpl(
           .post(url"${eisInstanceConfig.url}")
           .withBody(body)
           .setHeader(
-            HMRCHeaderNames.xRequestId       -> requestId.getOrElse(""),
-            HeaderNames.AUTHORIZATION        -> authorization,
-            RouterHeaderNames.CORRELATION_ID -> correlationId,
-            HeaderNames.ACCEPT               -> MimeTypes.XML,
-            RouterHeaderNames.CONVERSATION_ID -> ConversationId(
-              movementId,
-              MessageId("0000000000000000")
-            ).value.toString, // ConversationId(movementId, messageId).value.toString,
-            HeaderNames.DATE -> nowFormatted()
+            HMRCHeaderNames.xRequestId        -> requestId.getOrElse(""),
+            HeaderNames.AUTHORIZATION         -> authorization,
+            RouterHeaderNames.CORRELATION_ID  -> correlationId,
+            HeaderNames.ACCEPT                -> MimeTypes.XML,
+            RouterHeaderNames.CONVERSATION_ID -> ConversationId(movementId, messageId).value.toString,
+            HeaderNames.DATE                  -> nowFormatted()
           )
           .execute[HttpResponse]
           .flatMap[Either[RoutingError, Unit]] {

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
@@ -96,8 +96,6 @@ class EISConnectorSpec
       RetryPolicies.limitRetries[Future](1)(cats.implicits.catsStdInstancesForFuture(ec))
   }
 
-  val defaultMessageID = MessageId("0000000000000000")
-
   val uriStub = "/transit-movements-eis-stub/movements/messages"
 
   val connectorConfig: EISInstanceConfig = EISInstanceConfig(
@@ -154,8 +152,7 @@ class EISConnectorSpec
         // If a 500 error is returned, this most likely means a retry happened, the first place to look
         // should be the code the determines if a result is successful.
 
-        // val expectedConversationId = ConversationId(movementId, messageId)
-        val expectedConversationId = ConversationId(movementId, defaultMessageID)
+        val expectedConversationId = ConversationId(movementId, messageId)
         val requestId              = UUID.randomUUID().toString
 
         def stub(currentState: String, targetState: String, codeToReturn: Int) =
@@ -209,8 +206,7 @@ class EISConnectorSpec
         // If a 500 error is returned, this most likely means a retry happened, the first place to look
         // should be the code the determines if a result is successful.
 
-        // val expectedConversationId = ConversationId(movementId, messageId)
-        val expectedConversationId = ConversationId(movementId, defaultMessageID)
+        val expectedConversationId = ConversationId(movementId, messageId)
 
         def stub(currentState: String, targetState: String, codeToReturn: Int) =
           server.stubFor(
@@ -244,8 +240,7 @@ class EISConnectorSpec
       (connector, movementId, messageId) =>
         server.resetAll() // Need to reset due to the forAll - it's technically the same test
 
-        // val expectedConversationId = ConversationId(movementId, messageId)
-        val expectedConversationId = ConversationId(movementId, defaultMessageID)
+        val expectedConversationId = ConversationId(movementId, messageId)
 
         def stub(currentState: String, targetState: String, codeToReturn: Int) =
           server.stubFor(
@@ -279,8 +274,7 @@ class EISConnectorSpec
       (movementId, messageId) =>
         server.resetAll() // Need to reset due to the forAll - it's technically the same test
 
-        // val expectedConversationId = ConversationId(movementId, messageId)
-        val expectedConversationId = ConversationId(movementId, defaultMessageID)
+        val expectedConversationId = ConversationId(movementId, messageId)
 
         def stub(currentState: String, codeToReturn: Int) =
           server.stubFor(
@@ -311,8 +305,7 @@ class EISConnectorSpec
 
     "return unit when post is successful on retry if there is an initial failure" in forAll(arbitrary[MovementId], arbitrary[MessageId]) {
       (movementId, messageId) =>
-        // val expectedConversationId = ConversationId(movementId, messageId)
-        val expectedConversationId = ConversationId(movementId, defaultMessageID)
+        val expectedConversationId = ConversationId(movementId, messageId)
 
         def stub(currentState: String, targetState: String, codeToReturn: Int) =
           server.stubFor(
@@ -357,8 +350,7 @@ class EISConnectorSpec
       (statusCode, connector, movementId, messageId) =>
         server.resetAll() // Need to reset due to the forAll - it's technically the same test
 
-        // val expectedConversationId = ConversationId(movementId, messageId)
-        val expectedConversationId = ConversationId(movementId, defaultMessageID)
+        val expectedConversationId = ConversationId(movementId, messageId)
 
         server.stubFor(
           post(
@@ -411,7 +403,7 @@ class EISConnectorSpec
       server.resetAll()
       val connector = new EISConnectorImpl("Failure", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, OneRetry, clock, true)
 
-      val expectedConversationId = ConversationId(movementId, defaultMessageID)
+      val expectedConversationId = ConversationId(movementId, messageId)
 
       server.stubFor(
         post(
@@ -464,7 +456,7 @@ class EISConnectorSpec
       server.resetAll()
       val connector = new EISConnectorImpl("Failure", connectorConfig, TestHelpers.headerCarrierConfig, httpClientV2, OneRetry, clock, true)
 
-      val expectedConversationId = ConversationId(movementId, defaultMessageID)
+      val expectedConversationId = ConversationId(movementId, messageId)
 
       server.stubFor(
         post(

--- a/it/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
@@ -61,7 +61,6 @@ import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuiteWithGuice
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
-import uk.gov.hmrc.transitmovementsrouter.models.MovementId
 import uk.gov.hmrc.transitmovementsrouter.models.MovementType
 import uk.gov.hmrc.transitmovementsrouter.utils.UUIDGenerator
 
@@ -80,8 +79,6 @@ class MessagesControllerIntegrationSpec
     with Matchers
     with WiremockSuiteWithGuice
     with ScalaCheckDrivenPropertyChecks {
-
-  private val defaultMessageId = MessageId("0000000000000000")
 
   // We don't care about the content in this XML fragment, only the root tag and its child.
   val sampleIncomingXml: String =
@@ -250,12 +247,9 @@ class MessagesControllerIntegrationSpec
         // We do this instead of using the standard "app" because we otherwise get the error
         // "Trying to materialize stream after materializer has been shutdown".
         // We suspect it's due to nested tests.
-        val newApp = appBuilder.build()
-        //        val conversationId          = ConversationId(UUID.randomUUID())
-        //        val (movementId, messageId) = conversationId.toMovementAndMessageId
-        val movementId     = Gen.stringOfN(16, Gen.hexChar).map(MovementId.apply).sample.get
-        val messageId      = defaultMessageId
-        val conversationId = ConversationId(movementId, defaultMessageId)
+        val newApp                  = appBuilder.build()
+        val conversationId          = ConversationId(UUID.randomUUID())
+        val (movementId, messageId) = conversationId.toMovementAndMessageId
 
         server.stubFor(
           post(
@@ -296,12 +290,9 @@ class MessagesControllerIntegrationSpec
         // We do this instead of using the standard "app" because we otherwise get the error
         // "Trying to materialize stream after materializer has been shutdown".
         // We suspect it's due to nested tests.
-        val newApp = appBuilder.build()
-//        val conversationId          = ConversationId(UUID.randomUUID())
-//        val (movementId, messageId) = conversationId.toMovementAndMessageId
-        val movementId     = Gen.stringOfN(16, Gen.hexChar).map(MovementId.apply).sample.get
-        val messageId      = defaultMessageId
-        val conversationId = ConversationId(movementId, defaultMessageId)
+        val newApp                  = appBuilder.build()
+        val conversationId          = ConversationId(UUID.randomUUID())
+        val (movementId, messageId) = conversationId.toMovementAndMessageId
 
         val time      = OffsetDateTime.of(2023, 2, 14, 15, 55, 28, 0, ZoneOffset.UTC)
         val formatted = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH).withZone(ZoneOffset.UTC).format(time)
@@ -346,12 +337,9 @@ class MessagesControllerIntegrationSpec
         // We do this instead of using the standard "app" because we otherwise get the error
         // "Trying to materialize stream after materializer has been shutdown".
         // We suspect it's due to nested tests.
-        val newApp = appBuilder.build()
-        //        val conversationId          = ConversationId(UUID.randomUUID())
-        //        val (movementId, messageId) = conversationId.toMovementAndMessageId
-        val movementId     = Gen.stringOfN(16, Gen.hexChar).map(MovementId.apply).sample.get
-        val messageId      = defaultMessageId
-        val conversationId = ConversationId(movementId, defaultMessageId)
+        val newApp                  = appBuilder.build()
+        val conversationId          = ConversationId(UUID.randomUUID())
+        val (movementId, messageId) = conversationId.toMovementAndMessageId
 
         server.stubFor(
           post(
@@ -395,12 +383,9 @@ class MessagesControllerIntegrationSpec
         // We do this instead of using the standard "app" because we otherwise get the error
         // "Trying to materialize stream after materializer has been shutdown".
         // We suspect it's due to nested tests.
-        val newApp = appBuilder.build()
-        //        val conversationId          = ConversationId(UUID.randomUUID())
-        //        val (movementId, messageId) = conversationId.toMovementAndMessageId
-        val movementId     = Gen.stringOfN(16, Gen.hexChar).map(MovementId.apply).sample.get
-        val messageId      = defaultMessageId
-        val conversationId = ConversationId(movementId, defaultMessageId)
+        val newApp                  = appBuilder.build()
+        val conversationId          = ConversationId(UUID.randomUUID())
+        val (movementId, messageId) = conversationId.toMovementAndMessageId
 
         server.stubFor(
           post(


### PR DESCRIPTION
Reverts hmrc/transit-movements-router#61