### PR TITLE
CTCP 3210: Integrate NCTS monitoring tool

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/config/AppConfig.scala
@@ -40,8 +40,6 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: CTCServicesCon
 
   val pushNotificationsEnabled = servicesConfig.config("transit-movements-push-notifications").get[Boolean]("enabled")
 
-  lazy val messageSizeLimit: Int = config.get[Int]("messageSizeLimit")
-
   lazy val incomingAuth: IncomingAuthConfig = config.get[IncomingAuthConfig]("incomingRequestAuth")
 
   lazy val objectStoreUrl: String =
@@ -67,4 +65,9 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: CTCServicesCon
 
   lazy val internalAuthEnabled: Boolean = config.get[Boolean]("microservice.services.internal-auth.enabled")
   lazy val internalAuthToken: String    = config.get[String]("internal-auth.token")
+
+  lazy val serviceMonitoringUrl         = servicesConfig.baseUrl("ncts")
+  lazy val serviceMonitoringEnabled     = config.get[Boolean]("microservice.services.ncts.enabled")
+  lazy val serviceMonitoringOutgoingUri = config.get[String]("microservice.services.ncts.outgoing-uri")
+  lazy val serviceMonitoringIncomingUri = config.get[String]("microservice.services.ncts.incoming-uri")
 }

--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnector.scala
@@ -18,7 +18,11 @@ package uk.gov.hmrc.transitmovementsrouter.connectors
 
 import com.google.inject.ImplementedBy
 import com.google.inject.Inject
+import play.api.libs.json.JsValue
 import play.api.libs.json.Json
+import play.api.libs.ws.BodyWritable
+import play.api.libs.ws.JsonBodyWritables
+import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpReadsInstances._
 import uk.gov.hmrc.http.UpstreamErrorResponse
@@ -38,6 +42,7 @@ import java.net.URL
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import javax.activation.MimeType
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -57,6 +62,9 @@ class ServiceMonitoringConnectorImpl @Inject() (appConfig: AppConfig, httpClient
 
   private lazy val outgoingUrl = new URL(s"${appConfig.serviceMonitoringUrl}${appConfig.serviceMonitoringOutgoingUri}")
   private lazy val incomingUrl = new URL(s"${appConfig.serviceMonitoringUrl}${appConfig.serviceMonitoringIncomingUri}")
+
+  // The NCTS monitoring service expects a content type of text/plain, so this implicit enforces it
+  implicit private val serviceMonitoringBodyWritable: BodyWritable[JsValue] = BodyWritable(JsonBodyWritables.writeableOf_JsValue.transform, MimeTypes.TEXT)
 
   override def outgoing(movementId: MovementId, messageId: MessageId, messageType: MessageType, office: CustomsOffice)(implicit
     hc: HeaderCarrier,

--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnector.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.connectors
+
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.HttpReadsInstances._
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
+import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
+import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
+import uk.gov.hmrc.transitmovementsrouter.models.MessageId
+import uk.gov.hmrc.transitmovementsrouter.models.MessageType
+import uk.gov.hmrc.transitmovementsrouter.models.MovementId
+import uk.gov.hmrc.transitmovementsrouter.models.requests.IncomingServiceMonitoringRequest
+import uk.gov.hmrc.transitmovementsrouter.models.requests.OutgoingServiceMonitoringRequest
+import uk.gov.hmrc.transitmovementsrouter.models.requests.ServiceMonitoringRequests.incomingWrites
+import uk.gov.hmrc.transitmovementsrouter.models.requests.ServiceMonitoringRequests.outgoingWrites
+
+import java.net.URL
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+@ImplementedBy(classOf[ServiceMonitoringConnectorImpl])
+trait ServiceMonitoringConnector {
+
+  def outgoing(movementId: MovementId, messageId: MessageId, messageType: MessageType, office: CustomsOffice)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Unit]
+
+  def incoming(movementId: MovementId, messageId: MessageId, messageType: MessageType)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit]
+
+}
+
+class ServiceMonitoringConnectorImpl @Inject() (appConfig: AppConfig, httpClient: HttpClientV2, clock: Clock) extends ServiceMonitoringConnector {
+
+  private lazy val outgoingUrl = new URL(s"${appConfig.serviceMonitoringUrl}${appConfig.serviceMonitoringOutgoingUri}")
+  private lazy val incomingUrl = new URL(s"${appConfig.serviceMonitoringUrl}${appConfig.serviceMonitoringIncomingUri}")
+
+  override def outgoing(movementId: MovementId, messageId: MessageId, messageType: MessageType, office: CustomsOffice)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Unit] = {
+    val conversationId = ConversationId(movementId, messageId)
+    httpClient
+      .post(outgoingUrl)
+      .setHeader("X-Message-Sender" -> conversationId.value.toString)
+      .withBody(
+        Json.toJson(
+          OutgoingServiceMonitoringRequest(
+            conversationId,
+            LocalDateTime.now(clock.withZone(ZoneOffset.UTC)),
+            messageType,
+            office
+          )
+        )
+      )
+      .execute[Either[UpstreamErrorResponse, Unit]]
+      .flatMap {
+        case Right(x)    => Future.successful((): Unit)
+        case Left(error) => Future.failed(error)
+      }
+  }
+
+  override def incoming(movementId: MovementId, messageId: MessageId, messageType: MessageType)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Unit] =
+    httpClient
+      .post(incomingUrl)
+      .withBody(
+        Json.toJson(
+          IncomingServiceMonitoringRequest(
+            ConversationId(movementId, messageId),
+            LocalDateTime.now(clock.withZone(ZoneOffset.UTC)),
+            messageType
+          )
+        )
+      )
+      .execute[Either[UpstreamErrorResponse, Unit]]
+      .flatMap {
+        case Right(x)    => Future.successful((): Unit)
+        case Left(error) => Future.failed(error)
+      }
+}

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/ConversationId.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/ConversationId.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.Json
 import java.util.UUID
 
 object ConversationId {
-  implicit val conversationIdFormat: Format[ConversationId] = Json.format
+  implicit val conversationIdFormat: Format[ConversationId] = Json.valueFormat
 
   def apply(movementId: MovementId, messageId: MessageId): ConversationId = {
     val movementPart = s"${movementId.value.substring(0, 8)}-${movementId.value.substring(8, 12)}-${movementId.value.substring(12)}"

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/errors/ServiceMonitoringError.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/errors/ServiceMonitoringError.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.models.errors
+
+sealed trait ServiceMonitoringError
+
+object ServiceMonitoringError {
+  case class Unknown(cause: Option[Throwable]) extends ServiceMonitoringError
+}

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/requests/ServiceMonitoringRequests.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/requests/ServiceMonitoringRequests.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.models.requests
+
+import play.api.libs.json.JsString
+import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Writes
+import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
+import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
+import uk.gov.hmrc.transitmovementsrouter.models.MessageType
+
+import java.time.LocalDateTime
+
+object ServiceMonitoringRequests {
+
+  implicit private val messageTypeWrites: Writes[MessageType] = Writes {
+    messageType => JsString(messageType.code)
+  }
+
+  implicit private val officeWrites: Writes[CustomsOffice] = Writes {
+    office =>
+      if (office.value.length > 2) JsString(office.value.substring(0, 2))
+      else JsString(office.value)
+  }
+  implicit val outgoingWrites: OWrites[OutgoingServiceMonitoringRequest] = Json.writes[OutgoingServiceMonitoringRequest]
+
+  implicit val incomingWrites: OWrites[IncomingServiceMonitoringRequest] = Json.writes[IncomingServiceMonitoringRequest]
+
+}
+
+case class IncomingServiceMonitoringRequest(id: ConversationId, timestamp: LocalDateTime, messageCode: MessageType)
+case class OutgoingServiceMonitoringRequest(id: ConversationId, timestamp: LocalDateTime, messageCode: MessageType, office: CustomsOffice)

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/requests/ServiceMonitoringRequests.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/requests/ServiceMonitoringRequests.scala
@@ -25,20 +25,23 @@ import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
 import uk.gov.hmrc.transitmovementsrouter.models.MessageType
 
 import java.time.LocalDateTime
+import scala.annotation.unused
 
 object ServiceMonitoringRequests {
 
+  @unused // this is used in the macro below, but otherwise not used so the IDE flags it as such
   implicit private val messageTypeWrites: Writes[MessageType] = Writes {
     messageType => JsString(messageType.code)
   }
 
+  @unused // this is used in the macro below, but otherwise not used so the IDE flags it as such
   implicit private val officeWrites: Writes[CustomsOffice] = Writes {
     office =>
       if (office.value.length > 2) JsString(office.value.substring(0, 2))
       else JsString(office.value)
   }
-  implicit val outgoingWrites: OWrites[OutgoingServiceMonitoringRequest] = Json.writes[OutgoingServiceMonitoringRequest]
 
+  implicit val outgoingWrites: OWrites[OutgoingServiceMonitoringRequest] = Json.writes[OutgoingServiceMonitoringRequest]
   implicit val incomingWrites: OWrites[IncomingServiceMonitoringRequest] = Json.writes[IncomingServiceMonitoringRequest]
 
 }

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/MessageTypeExtractor.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/MessageTypeExtractor.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.transitmovementsrouter.services
 
-import akka.event.Logging
 import akka.stream.Attributes
 import akka.stream.Materializer
 import akka.stream.alpakka.xml.StartElement

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreService.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/ObjectStoreService.scala
@@ -73,7 +73,11 @@ class ObjectStoreServiceImpl @Inject() (clock: Clock, appConfig: AppConfig, clie
         contentMd5 = None
       )
     }.leftMap {
-      case NonFatal(thr) => ObjectStoreError.UnexpectedError(thr = Some(thr))
+      error =>
+        // avoids exhaustivity warnings
+        (error: @unchecked) match {
+          case NonFatal(thr) => ObjectStoreError.UnexpectedError(thr = Some(thr))
+        }
     }
 
   private def dateFormat =

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/ServiceMonitoringService.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/ServiceMonitoringService.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.services
+
+import cats.data.EitherT
+import com.google.inject.ImplementedBy
+import com.google.inject.Inject
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
+import uk.gov.hmrc.transitmovementsrouter.connectors.ServiceMonitoringConnector
+import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
+import uk.gov.hmrc.transitmovementsrouter.models.MessageId
+import uk.gov.hmrc.transitmovementsrouter.models.MessageType
+import uk.gov.hmrc.transitmovementsrouter.models.MovementId
+import uk.gov.hmrc.transitmovementsrouter.models.errors.ServiceMonitoringError
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+@ImplementedBy(classOf[ServiceMonitoringServiceImpl])
+trait ServiceMonitoringService {
+
+  def outgoing(movementId: MovementId, messageId: MessageId, messageType: MessageType, office: CustomsOffice)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, ServiceMonitoringError, Unit]
+
+  def incoming(movementId: MovementId, messageId: MessageId, messageType: MessageType)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, ServiceMonitoringError, Unit]
+
+}
+
+class ServiceMonitoringServiceImpl @Inject() (appConfig: AppConfig, statusMonitoringConnector: ServiceMonitoringConnector) extends ServiceMonitoringService {
+
+  override def outgoing(movementId: MovementId, messageId: MessageId, messageType: MessageType, office: CustomsOffice)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, ServiceMonitoringError, Unit] =
+    if (appConfig.serviceMonitoringEnabled) {
+      EitherT {
+        statusMonitoringConnector
+          .outgoing(movementId, messageId, messageType, office)
+          .map(Right.apply)
+          .recover {
+            case NonFatal(ex) => Left(ServiceMonitoringError.Unknown(Some(ex)))
+          }
+      }
+    } else EitherT.rightT(())
+
+  override def incoming(movementId: MovementId, messageId: MessageId, messageType: MessageType)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, ServiceMonitoringError, Unit] =
+    if (appConfig.serviceMonitoringEnabled) {
+      EitherT {
+        statusMonitoringConnector
+          .incoming(movementId, messageId, messageType)
+          .map(Right.apply)
+          .recover {
+            case NonFatal(ex) => Left(ServiceMonitoringError.Unknown(Some(ex)))
+          }
+      }
+    } else EitherT.rightT(())
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -210,6 +210,15 @@ microservice {
        file-ready-uri = "/sdes-stub/notification/fileready"
     }
 
+    # NCTS Status Monitoring tool, rather than NCTS itself
+    # It's named ncts in the catalogue, so we'll name it as such here.
+    ncts {
+      enabled = false
+      host = localhost
+      port = 9516
+      outgoing-uri = "/ncts/movement-notification"
+      incoming-uri = "/ncts/response-notification"
+    }
   }
 }
 

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/EISConnectorSpec.scala
@@ -44,11 +44,11 @@ import uk.gov.hmrc.transitmovementsrouter.config.CircuitBreakerConfig
 import uk.gov.hmrc.transitmovementsrouter.config.EISInstanceConfig
 import uk.gov.hmrc.transitmovementsrouter.config.Headers
 import uk.gov.hmrc.transitmovementsrouter.config.RetryConfig
-import uk.gov.hmrc.transitmovementsrouter.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.it.base.RegexPatterns
 import uk.gov.hmrc.transitmovementsrouter.it.base.TestActorSystem
 import uk.gov.hmrc.transitmovementsrouter.it.base.TestHelpers
 import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MovementId

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/PersistenceConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/PersistenceConnectorSpec.scala
@@ -40,8 +40,8 @@ import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.test.HttpClientV2Support
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
-import uk.gov.hmrc.transitmovementsrouter.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.MessageType.DeclarationAmendment
 import uk.gov.hmrc.transitmovementsrouter.models._
 import uk.gov.hmrc.transitmovementsrouter.models.errors.PersistenceError.MessageNotFound
@@ -200,7 +200,7 @@ class PersistenceConnectorSpec
 
         whenReady(connector.patchMessageStatus(movementId, messageId, MessageUpdate(MessageStatus.Success)).value) {
           case Left(error) =>
-            statusCode match {
+            (statusCode: @unchecked) match {
               case BAD_REQUEST           => error mustBe a[Unexpected]
               case NOT_FOUND             => error mustBe a[MessageNotFound]
               case INTERNAL_SERVER_ERROR => error mustBe a[Unexpected]

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/PushNotificationConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/PushNotificationConnectorSpec.scala
@@ -44,9 +44,9 @@ import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.test.HttpClientV2Support
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
-import uk.gov.hmrc.transitmovementsrouter.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.it.base.TestActorSystem
 import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.errors.PushNotificationError.MovementNotFound
 import uk.gov.hmrc.transitmovementsrouter.models.errors.PushNotificationError.Unexpected
 import uk.gov.hmrc.transitmovementsrouter.services.EISMessageTransformersImpl

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/SDESConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/SDESConnectorSpec.scala
@@ -47,8 +47,8 @@ import uk.gov.hmrc.transitmovementsrouter.it.base.TestActorSystem
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
 import uk.gov.hmrc.transitmovementsrouter.controllers.errors.PresentationError
 import uk.gov.hmrc.transitmovementsrouter.controllers.errors.StandardError
-import uk.gov.hmrc.transitmovementsrouter.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MovementId

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnectorSpec.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import org.mockito.Mockito.when
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.http.test.HttpClientV2Support
+import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
+import uk.gov.hmrc.transitmovementsrouter.it.base.TestActorSystem
+import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
+import uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
+import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
+import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
+import uk.gov.hmrc.transitmovementsrouter.models.MessageId
+import uk.gov.hmrc.transitmovementsrouter.models.MessageType
+import uk.gov.hmrc.transitmovementsrouter.models.MovementId
+
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ServiceMonitoringConnectorSpec
+    extends AnyFreeSpec
+    with Matchers
+    with WiremockSuite
+    with TestActorSystem
+    with HttpClientV2Support
+    with ScalaFutures
+    with ScalaCheckDrivenPropertyChecks
+    with ModelGenerators {
+
+  implicit val timeout: PatienceConfig = PatienceConfig(2.seconds, 2.seconds)
+  implicit val hc: HeaderCarrier       = HeaderCarrier()
+
+  private lazy val clock = Clock.fixed(LocalDateTime.of(2023, 6, 23, 15, 57, 58, 234000000).toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+
+  val mockAppConfig: AppConfig = mock[AppConfig]
+  when(mockAppConfig.serviceMonitoringUrl).thenReturn(s"http://localhost:$wiremockPort")
+  when(mockAppConfig.serviceMonitoringIncomingUri).thenReturn("/incoming")
+  when(mockAppConfig.serviceMonitoringOutgoingUri).thenReturn("/outgoing")
+
+  "outgoing" - {
+    "when successful" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType], arbitrary[CustomsOffice]) {
+      (movementId, messageId, messageType, customsOffice) =>
+        server.resetAll()
+
+        val expectedConversationId = ConversationId(movementId, messageId)
+
+        server.stubFor(
+          post("/outgoing")
+            .withHeader("X-Message-Sender", equalTo(expectedConversationId.value.toString))
+            .withRequestBody(
+              equalToJson(
+                s"""{
+                  |    "id": "${expectedConversationId.value.toString}",
+                  |    "timestamp": "2023-06-23T15:57:58.234",
+                  |    "messageCode": "${messageType.code}",
+                  |    "office": "${customsOffice.value.substring(0, 2)}"
+                  |}
+                  |""".stripMargin
+              )
+            )
+            .willReturn(aResponse().withStatus(200))
+        )
+        val sut = new ServiceMonitoringConnectorImpl(mockAppConfig, httpClientV2, clock)
+        whenReady(sut.outgoing(movementId, messageId, messageType, customsOffice)) {
+          _ => succeed
+        }
+
+    }
+
+    "when not successful" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType], arbitrary[CustomsOffice]) {
+      (movementId, messageId, messageType, customsOffice) =>
+        server.resetAll()
+
+        val expectedConversationId = ConversationId(movementId, messageId)
+
+        server.stubFor(
+          post("/outgoing")
+            .withRequestBody(
+              equalToJson(
+                s"""{
+                   |    "id": "${expectedConversationId.value.toString}",
+                   |    "timestamp": "2023-06-23T15:57:58.234",
+                   |    "messageCode": "${messageType.code}",
+                   |    "office": "${customsOffice.value.substring(0, 2)}"
+                   |}
+                   |""".stripMargin
+              )
+            )
+            .willReturn(aResponse().withStatus(500))
+        )
+        val sut = new ServiceMonitoringConnectorImpl(mockAppConfig, httpClientV2, clock)
+        whenReady(
+          sut
+            .outgoing(movementId, messageId, messageType, customsOffice)
+            .map(
+              _ => fail("Expected a failure, got a success")
+            )
+            .recover {
+              case UpstreamErrorResponse(_, 500, _, _) => (): Unit
+            }
+        ) {
+          _ => succeed // will only execute if the upstream response was 500
+        }
+
+    }
+  }
+
+  "incoming" - {
+    "when successful" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType]) {
+      (movementId, messageId, messageType) =>
+        server.resetAll()
+
+        val expectedConversationId = ConversationId(movementId, messageId)
+
+        server.stubFor(
+          post("/incoming")
+            .withRequestBody(
+              equalToJson(
+                s"""{
+                   |    "id": "${expectedConversationId.value.toString}",
+                   |    "timestamp": "2023-06-23T15:57:58.234",
+                   |    "messageCode": "${messageType.code}"
+                   |}
+                   |""".stripMargin
+              )
+            )
+            .willReturn(aResponse().withStatus(200))
+        )
+        val sut = new ServiceMonitoringConnectorImpl(mockAppConfig, httpClientV2, clock)
+        whenReady(sut.incoming(movementId, messageId, messageType)) {
+          _ => succeed
+        }
+
+    }
+
+    "when not successful" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType]) {
+      (movementId, messageId, messageType) =>
+        server.resetAll()
+
+        val expectedConversationId = ConversationId(movementId, messageId)
+
+        server.stubFor(
+          post("/incoming")
+            .withRequestBody(
+              equalToJson(
+                s"""{
+                   |    "id": "${expectedConversationId.value.toString}",
+                   |    "timestamp": "2023-06-23T15:57:58.234",
+                   |    "messageCode": "${messageType.code}"
+                   |}
+                   |""".stripMargin
+              )
+            )
+            .willReturn(aResponse().withStatus(500))
+        )
+        val sut = new ServiceMonitoringConnectorImpl(mockAppConfig, httpClientV2, clock)
+        whenReady(
+          sut
+            .incoming(movementId, messageId, messageType)
+            .map(
+              _ => fail("Expected a failure, got a success")
+            )
+            .recover {
+              case UpstreamErrorResponse(_, 500, _, _) => (): Unit
+            }
+        ) {
+          _ => succeed // will only execute if the upstream response was 500
+        }
+
+    }
+  }
+
+}

--- a/it/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/connectors/ServiceMonitoringConnectorSpec.scala
@@ -76,6 +76,7 @@ class ServiceMonitoringConnectorSpec
         server.stubFor(
           post("/outgoing")
             .withHeader("X-Message-Sender", equalTo(expectedConversationId.value.toString))
+            .withHeader("Content-Type", equalTo("text/plain; charset=UTF-8"))
             .withRequestBody(
               equalToJson(
                 s"""{
@@ -104,6 +105,7 @@ class ServiceMonitoringConnectorSpec
 
         server.stubFor(
           post("/outgoing")
+            .withHeader("Content-Type", equalTo("text/plain; charset=UTF-8"))
             .withRequestBody(
               equalToJson(
                 s"""{
@@ -143,6 +145,7 @@ class ServiceMonitoringConnectorSpec
 
         server.stubFor(
           post("/incoming")
+            .withHeader("Content-Type", equalTo("text/plain; charset=UTF-8"))
             .withRequestBody(
               equalToJson(
                 s"""{
@@ -170,6 +173,7 @@ class ServiceMonitoringConnectorSpec
 
         server.stubFor(
           post("/incoming")
+            .withHeader("Content-Type", equalTo("text/plain; charset=UTF-8"))
             .withRequestBody(
               equalToJson(
                 s"""{

--- a/it/uk/gov/hmrc/transitmovementsrouter/it/generators/BaseGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/it/generators/BaseGenerators.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.transitmovementsrouter.generators
+package uk.gov.hmrc.transitmovementsrouter.it.generators
 
 import cats.data.NonEmptyList
 import org.scalacheck.Arbitrary.arbitrary

--- a/it/uk/gov/hmrc/transitmovementsrouter/it/generators/ModelGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovementsrouter/it/generators/ModelGenerators.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.transitmovementsrouter.generators
+package uk.gov.hmrc.transitmovementsrouter.it.generators
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen

--- a/test/uk/gov/hmrc/transitmovementsrouter/services/ServiceMonitoringServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/services/ServiceMonitoringServiceSpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsrouter.services
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchersSugar.eqTo
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.when
+import org.mockito.MockitoSugar.mock
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
+import uk.gov.hmrc.transitmovementsrouter.connectors.ServiceMonitoringConnector
+import uk.gov.hmrc.transitmovementsrouter.generators.TestModelGenerators
+import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
+import uk.gov.hmrc.transitmovementsrouter.models.MessageId
+import uk.gov.hmrc.transitmovementsrouter.models.MessageType
+import uk.gov.hmrc.transitmovementsrouter.models.MovementId
+import uk.gov.hmrc.transitmovementsrouter.models.errors.ServiceMonitoringError
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ServiceMonitoringServiceSpec extends AnyFreeSpec with Matchers with TestModelGenerators with ScalaFutures with ScalaCheckDrivenPropertyChecks {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  "outgoing" - {
+    "if turned off, will just return Unit" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType], arbitrary[CustomsOffice]) {
+      (movementId, messageId, messageType, customsOffice) =>
+        val mockAppConfig = mock[AppConfig]
+        when(mockAppConfig.serviceMonitoringEnabled).thenReturn(false)
+
+        val mockConnector = mock[ServiceMonitoringConnector]
+
+        val sut = new ServiceMonitoringServiceImpl(mockAppConfig, mockConnector)
+        whenReady(sut.outgoing(movementId, messageId, messageType, customsOffice).value) {
+          case Right(()) =>
+            verifyNoInteractions(mockConnector)
+          case Left(_) => fail("Expected Right of Unit")
+        }
+    }
+
+    "if turned on" - {
+      val mockAppConfig = mock[AppConfig]
+      when(mockAppConfig.serviceMonitoringEnabled).thenReturn(true)
+
+      "and the connector succeeds, return Right of unit" in forAll(
+        arbitrary[MovementId],
+        arbitrary[MessageId],
+        arbitrary[MessageType],
+        arbitrary[CustomsOffice]
+      ) {
+        (movementId, messageId, messageType, customsOffice) =>
+          val mockConnector = mock[ServiceMonitoringConnector]
+          when(mockConnector.outgoing(eqTo(movementId), eqTo(messageId), eqTo(messageType), eqTo(customsOffice))(any(), any()))
+            .thenReturn(Future.successful((): Unit))
+
+          val sut = new ServiceMonitoringServiceImpl(mockAppConfig, mockConnector)
+          whenReady(sut.outgoing(movementId, messageId, messageType, customsOffice).value) {
+            case Right(()) =>
+              verify(mockConnector, times(1))
+                .outgoing(eqTo(movementId), eqTo(messageId), eqTo(messageType), eqTo(customsOffice))(any(), any())
+            case Left(_) => fail("Expecting a Right of Unit")
+          }
+      }
+
+      "and the connector succeeds, return Left of Unexpected" in forAll(
+        arbitrary[MovementId],
+        arbitrary[MessageId],
+        arbitrary[MessageType],
+        arbitrary[CustomsOffice]
+      ) {
+        (movementId, messageId, messageType, customsOffice) =>
+          val mockConnector = mock[ServiceMonitoringConnector]
+          val expected      = new IllegalStateException("error")
+          when(mockConnector.outgoing(eqTo(movementId), eqTo(messageId), eqTo(messageType), eqTo(customsOffice))(any(), any()))
+            .thenReturn(Future.failed(expected))
+
+          val sut = new ServiceMonitoringServiceImpl(mockAppConfig, mockConnector)
+          whenReady(sut.outgoing(movementId, messageId, messageType, customsOffice).value) {
+            case Left(ServiceMonitoringError.Unknown(Some(`expected`))) =>
+              verify(mockConnector, times(1))
+                .outgoing(eqTo(movementId), eqTo(messageId), eqTo(messageType), eqTo(customsOffice))(any(), any())
+            case _ => fail("Expecting a Left of an Unexpected")
+          }
+      }
+
+    }
+  }
+
+  "incoming" - {
+    "if turned off, will just return Unit" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType]) {
+      (movementId, messageId, messageType) =>
+        val mockAppConfig = mock[AppConfig]
+        when(mockAppConfig.serviceMonitoringEnabled).thenReturn(false)
+
+        val mockConnector = mock[ServiceMonitoringConnector]
+
+        val sut = new ServiceMonitoringServiceImpl(mockAppConfig, mockConnector)
+        whenReady(sut.incoming(movementId, messageId, messageType).value) {
+          case Right(()) =>
+            verifyNoInteractions(mockConnector)
+          case Left(_) => fail("Expected Right of Unit")
+        }
+    }
+
+    "if turned on" - {
+      val mockAppConfig = mock[AppConfig]
+      when(mockAppConfig.serviceMonitoringEnabled).thenReturn(true)
+
+      "and the connector succeeds, return Right of unit" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType]) {
+        (movementId, messageId, messageType) =>
+          val mockConnector = mock[ServiceMonitoringConnector]
+          when(mockConnector.incoming(eqTo(movementId), eqTo(messageId), eqTo(messageType))(any(), any()))
+            .thenReturn(Future.successful((): Unit))
+
+          val sut = new ServiceMonitoringServiceImpl(mockAppConfig, mockConnector)
+          whenReady(sut.incoming(movementId, messageId, messageType).value) {
+            case Right(()) =>
+              verify(mockConnector, times(1))
+                .incoming(eqTo(movementId), eqTo(messageId), eqTo(messageType))(any(), any())
+            case Left(_) => fail("Expecting a Right of Unit")
+          }
+      }
+
+      "and the connector succeeds, return Left of Unexpected" in forAll(arbitrary[MovementId], arbitrary[MessageId], arbitrary[MessageType]) {
+        (movementId, messageId, messageType) =>
+          val mockConnector = mock[ServiceMonitoringConnector]
+          val expected      = new IllegalStateException("error")
+          when(mockConnector.incoming(eqTo(movementId), eqTo(messageId), eqTo(messageType))(any(), any()))
+            .thenReturn(Future.failed(expected))
+
+          val sut = new ServiceMonitoringServiceImpl(mockAppConfig, mockConnector)
+          whenReady(sut.incoming(movementId, messageId, messageType).value) {
+            case Left(ServiceMonitoringError.Unknown(Some(`expected`))) =>
+              verify(mockConnector, times(1))
+                .incoming(eqTo(movementId), eqTo(messageId), eqTo(messageType))(any(), any())
+            case _ => fail("Expecting a Left of an Unexpected")
+          }
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
This completely follows the P4 spec and there will be a couple of things that will need to be done in the tool itself.

Note that it accepts a content type of `text/plain` only(!), so we need to force that, even though we send Json (and do for P4)...