### PR TITLE
get the ClientID and EORI number from updatemovementresponse and pass to auditing service

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/BaseConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/BaseConnector.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.transitmovementsrouter.connectors
 import play.api.http.HeaderNames
 import uk.gov.hmrc.http.client.RequestBuilder
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
+import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageType
@@ -47,6 +48,11 @@ trait BaseConnector {
     def withEoriNumber(eoriNumber: Option[EoriNumber]): RequestBuilder =
       if (eoriNumber.isDefined)
         requestBuilder.setHeader("X-Audit-Meta-EORI" -> eoriNumber.get.value)
+      else requestBuilder
+
+    def withClientId(clientId: Option[ClientId]): RequestBuilder =
+      if (clientId.isDefined)
+        requestBuilder.setHeader("X-Client-Id" -> clientId.get.value)
       else requestBuilder
 
     def withMovementType(movementType: Option[MovementType]): RequestBuilder =

--- a/app/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesController.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesController.scala
@@ -251,7 +251,8 @@ class MessagesController @Inject() (
                   None,
                   None,
                   Some(messageType.movementType),
-                  Some(messageType)
+                  Some(messageType),
+                  None
                 )
               (err, Option(messageType))
           }
@@ -262,18 +263,20 @@ class MessagesController @Inject() (
             payload = source.lift(3).get,
             movementId = Some(movementId),
             messageId = Some(persistenceResponse.messageId),
-            enrolmentEori = None,
+            enrolmentEORI = Some(persistenceResponse.eori),
             movementType = Some(messageType.movementType),
-            messageType = Some(messageType)
+            messageType = Some(messageType),
+            clientId = persistenceResponse.clientId
           )
           _ = auditService.auditStatusEvent(
             NCTSToTraderSubmissionSuccessful,
             None,
             Some(movementId),
             Some(persistenceResponse.messageId),
-            None,
+            enrolmentEORI = Some(persistenceResponse.eori),
             Some(messageType.movementType),
-            Some(messageType)
+            Some(messageType),
+            clientId = persistenceResponse.clientId
           )
           _ = logIncomingSuccess(movementId, triggerId, persistenceResponse.messageId, messageType)
         } yield persistenceResponse)

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/ClientId.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/ClientId.scala
@@ -17,10 +17,9 @@
 package uk.gov.hmrc.transitmovementsrouter.models
 
 import play.api.libs.json.Json
-import uk.gov.hmrc.transitmovementsrouter.models.formats.CommonFormats
 
-case class PersistenceResponse(messageId: MessageId, eori: EoriNumber, clientId: Option[ClientId])
-
-object PersistenceResponse extends CommonFormats {
-  implicit val format = Json.format[PersistenceResponse]
+object ClientId {
+  implicit val clientIdFormat = Json.valueFormat[ClientId]
 }
+
+case class ClientId(value: String) extends AnyVal

--- a/app/uk/gov/hmrc/transitmovementsrouter/models/requests/Metadata.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/models/requests/Metadata.scala
@@ -32,7 +32,7 @@ case class Metadata(
   path: String,
   movementId: Option[MovementId],
   messageId: Option[MessageId],
-  enrolmentEori: Option[EoriNumber],
+  enrolmentEORI: Option[EoriNumber],
   movementType: Option[MovementType],
   messageType: Option[MessageType]
 )

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/AuditingService.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/AuditingService.scala
@@ -25,6 +25,7 @@ import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.transitmovementsrouter.connectors.AuditingConnector
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType
+import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageType
@@ -43,9 +44,10 @@ trait AuditingService {
     payload: Option[JsValue],
     movementId: Option[MovementId],
     messageId: Option[MessageId],
-    enrolmentEori: Option[EoriNumber],
+    enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
-    messageType: Option[MessageType]
+    messageType: Option[MessageType],
+    clientId: Option[ClientId]
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -58,9 +60,10 @@ trait AuditingService {
     payload: Source[ByteString, _],
     movementId: Option[MovementId],
     messageId: Option[MessageId],
-    enrolmentEori: Option[EoriNumber],
+    enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
-    messageType: Option[MessageType]
+    messageType: Option[MessageType],
+    clientId: Option[ClientId]
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -77,31 +80,35 @@ class AuditingServiceImpl @Inject() (auditingConnector: AuditingConnector) exten
     payload: Source[ByteString, _],
     movementId: Option[MovementId],
     messageId: Option[MessageId],
-    enrolmentEori: Option[EoriNumber],
+    enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
-    messageType: Option[MessageType]
+    messageType: Option[MessageType],
+    clientId: Option[ClientId]
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[Unit] =
-    auditingConnector.postMessageType(auditType, contentType, contentLength, payload, movementId, messageId, enrolmentEori, movementType, messageType).recover {
-      case NonFatal(e) =>
-        logger.warn("Unable to audit payload due to an exception", e)
-    }
+    auditingConnector
+      .postMessageType(auditType, contentType, contentLength, payload, movementId, messageId, enrolmentEORI, movementType, messageType, clientId)
+      .recover {
+        case NonFatal(e) =>
+          logger.warn("Unable to audit payload due to an exception", e)
+      }
 
   def auditStatusEvent(
     auditType: AuditType,
     payload: Option[JsValue],
     movementId: Option[MovementId],
     messageId: Option[MessageId],
-    enrolmentEori: Option[EoriNumber],
+    enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
-    messageType: Option[MessageType]
+    messageType: Option[MessageType],
+    clientId: Option[ClientId]
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[Unit] =
-    auditingConnector.postStatus(auditType, payload, movementId, messageId, enrolmentEori, movementType, messageType).recover {
+    auditingConnector.postStatus(auditType, payload, movementId, messageId, enrolmentEORI, movementType, messageType, clientId).recover {
       case NonFatal(e) =>
         logger.warn("Unable to audit payload due to an exception", e)
 

--- a/it/test/uk/gov/hmrc/transitmovementsrouter/connectors/AuditingConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/transitmovementsrouter/connectors/AuditingConnectorSpec.scala
@@ -49,6 +49,7 @@ import test.uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models._
 import uk.gov.hmrc.transitmovementsrouter.models.requests.Details
 import uk.gov.hmrc.transitmovementsrouter.models.requests.Metadata
+import uk.gov.hmrc.transitmovementsrouter.utils.RouterHeaderNames.CLIENT_ID
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -317,6 +318,7 @@ class AuditingConnectorSpec
             urlEqualTo(targetUrl(AuditType.AmendmentAcceptance))
           )
             .withHeader(HeaderNames.AUTHORIZATION, equalTo(token))
+            .withHeader(CLIENT_ID, equalTo("1234"))
             .withHeader(HeaderNames.CONTENT_TYPE, equalTo("application/json"))
             .withHeader("X-Audit-Source", equalTo("transit-movements-router"))
             .withRequestBody(
@@ -340,7 +342,8 @@ class AuditingConnectorSpec
           messageId,
           eori,
           movementType,
-          messageType
+          messageType,
+          Some(ClientId("1234"))
         )
 
         // then the future should be ready
@@ -365,6 +368,7 @@ class AuditingConnectorSpec
                 urlEqualTo(targetUrl(AuditType.AmendmentAcceptance))
               )
                 .withHeader(HeaderNames.AUTHORIZATION, equalTo(token))
+                .withHeader(CLIENT_ID, equalTo("1234"))
                 .withHeader(HeaderNames.CONTENT_TYPE, equalTo("application/json"))
                 .withHeader("X-Audit-Source", equalTo("transit-movements-router"))
                 .withRequestBody(
@@ -388,7 +392,8 @@ class AuditingConnectorSpec
               messageId,
               eori,
               movementType,
-              messageType
+              messageType,
+              Some(ClientId("1234"))
             )
 
             val result = future

--- a/it/test/uk/gov/hmrc/transitmovementsrouter/connectors/PersistenceConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/transitmovementsrouter/connectors/PersistenceConnectorSpec.scala
@@ -66,6 +66,8 @@ class PersistenceConnectorSpec
 
   val movementId     = arbitraryMovementId.arbitrary.sample.get
   val messageId      = arbitraryMessageId.arbitrary.sample.get
+  val eoriNumber     = arbitraryEoriNumber.arbitrary.sample.get
+  val clientId       = arbitraryClientId.arbitrary.sample.get
   val objectStoreURI = s"common-transit-convention-traders/movements/${movementId.value}/${ConversationId(movementId, messageId).value.toString}.xml"
 
   val uriPersistence = Url(
@@ -135,13 +137,13 @@ class PersistenceConnectorSpec
   "post" should {
     "return messageId when post is successful" in {
 
-      val body = Json.obj("messageId" -> messageId.value).toString()
+      val body = Json.obj("messageId" -> messageId.value, "eori" -> eoriNumber, "clientId" -> Option(clientId)).toString()
 
       stubForPostBody(OK, Some(body))
       whenReady(connector.postBody(movementId, messageId, DeclarationAmendment, source).value) {
         x =>
           x.isRight mustBe true
-          x mustBe Right(PersistenceResponse(messageId))
+          x mustBe Right(PersistenceResponse(messageId, eoriNumber, Option(clientId)))
       }
     }
 

--- a/it/test/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesControllerIntegrationSpec.scala
@@ -519,6 +519,8 @@ class MessagesControllerIntegrationSpec
           val conversationId          = ConversationId(UUID.randomUUID())
           val (movementId, messageId) = conversationId.toMovementAndMessageId
           val outputMessageId         = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+          val eoriNumber              = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+          val clientId                = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
 
           // We should hit the persistence layer on /transit-movements/traders/movements/${movementId.value}/messages?triggerId=messageId
           server.stubFor(
@@ -526,7 +528,7 @@ class MessagesControllerIntegrationSpec
               .withQueryParam("triggerId", new EqualToPattern(messageId.value))
               .withHeader("x-message-type", new EqualToPattern("IE004"))
               .willReturn(
-                aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId)))
+                aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId, "eori" -> eoriNumber, "clientId" -> clientId)))
               )
           )
 
@@ -563,6 +565,8 @@ class MessagesControllerIntegrationSpec
       val conversationId          = ConversationId(UUID.randomUUID())
       val (movementId, messageId) = conversationId.toMovementAndMessageId
       val outputMessageId         = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+      val eoriNumber              = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+      val clientId                = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
 
       // We should hit the persistence layer on /transit-movements/traders/movements/${movementId.value}/messages?triggerId=messageId
       server.stubFor(
@@ -570,7 +574,7 @@ class MessagesControllerIntegrationSpec
           .withQueryParam("triggerId", new EqualToPattern(messageId.value))
           .withHeader("x-message-type", new EqualToPattern("IE015"))
           .willReturn(
-            aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId)))
+            aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId, "eori" -> eoriNumber, "clientId" -> clientId)))
           )
       )
 
@@ -606,14 +610,15 @@ class MessagesControllerIntegrationSpec
       val conversationId          = ConversationId(UUID.randomUUID())
       val (movementId, messageId) = conversationId.toMovementAndMessageId
       val outputMessageId         = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
-
+      val eoriNumber              = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+      val clientId                = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
       // We should hit the persistence layer on /transit-movements/traders/movements/${movementId.value}/messages?triggerId=messageId
       server.stubFor(
         post(new UrlPathPattern(new EqualToPattern(s"/transit-movements/traders/movements/${movementId.value}/messages"), false))
           .withQueryParam("triggerId", new EqualToPattern(messageId.value))
           .withHeader("x-message-type", new EqualToPattern("IE015"))
           .willReturn(
-            aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId)))
+            aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId, "eori" -> eoriNumber, "clientId" -> clientId)))
           )
       )
 
@@ -649,6 +654,8 @@ class MessagesControllerIntegrationSpec
       val conversationId          = ConversationId(UUID.randomUUID())
       val (movementId, messageId) = conversationId.toMovementAndMessageId
       val outputMessageId         = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+      val eoriNumber              = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
+      val clientId                = Gen.stringOfN(16, Gen.hexChar.map(_.toLower)).sample.get
 
       // We should hit the persistence layer on /transit-movements/traders/movements/${movementId.value}/messages?triggerId=messageId
       server.stubFor(
@@ -656,7 +663,7 @@ class MessagesControllerIntegrationSpec
           .withQueryParam("triggerId", new EqualToPattern(messageId.value))
           .withHeader("x-message-type", new EqualToPattern("IE015"))
           .willReturn(
-            aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId)))
+            aResponse().withStatus(OK).withBody(Json.stringify(Json.obj("messageId" -> outputMessageId, "eori" -> eoriNumber, "clientId" -> clientId)))
           )
       )
 

--- a/it/test/uk/gov/hmrc/transitmovementsrouter/it/generators/ModelGenerators.scala
+++ b/it/test/uk/gov/hmrc/transitmovementsrouter/it/generators/ModelGenerators.scala
@@ -21,6 +21,7 @@ import org.scalacheck.Gen
 import uk.gov.hmrc.objectstore.client.Md5Hash
 import uk.gov.hmrc.objectstore.client.ObjectSummaryWithMd5
 import uk.gov.hmrc.objectstore.client.Path
+import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.ConversationId
 import uk.gov.hmrc.transitmovementsrouter.models.CustomsOffice
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
@@ -127,6 +128,10 @@ trait ModelGenerators extends BaseGenerators {
 
   implicit lazy val arbitraryMovementType: Arbitrary[MovementType] = Arbitrary {
     Gen.oneOf(Seq(MovementType("departure"), MovementType("arrival")))
+  }
+
+  implicit lazy val arbitraryClientId: Arbitrary[ClientId] = Arbitrary {
+    Gen.stringOfN(24, Gen.alphaNumChar).map(ClientId.apply)
   }
 
   implicit val arbitraryMetadata: Arbitrary[Metadata] = Arbitrary {

--- a/test/uk/gov/hmrc/transitmovementsrouter/generators/TestModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/generators/TestModelGenerators.scala
@@ -75,6 +75,10 @@ trait TestModelGenerators extends BaseGenerators {
       Gen.listOfN(16, Gen.hexChar).map(_.mkString.toLowerCase).map(MessageId(_))
     }
 
+  implicit lazy val arbitraryClientId: Arbitrary[ClientId] = Arbitrary {
+    Gen.stringOfN(24, Gen.alphaNumChar).map(ClientId.apply)
+  }
+
   implicit lazy val arbitraryConversationId: Arbitrary[ConversationId] =
     Arbitrary {
       for {

--- a/test/uk/gov/hmrc/transitmovementsrouter/services/AuditingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/services/AuditingServiceSpec.scala
@@ -41,6 +41,7 @@ import uk.gov.hmrc.transitmovementsrouter.connectors.AuditingConnector
 import uk.gov.hmrc.transitmovementsrouter.generators.TestModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType.AmendmentAcceptance
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType
+import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
 import uk.gov.hmrc.transitmovementsrouter.models.MessageId
 import uk.gov.hmrc.transitmovementsrouter.models.MessageType
@@ -76,9 +77,10 @@ class AuditingServiceSpec
             Gen.option(arbitrary[MovementType]),
             Gen.option(arbitrary[MovementId]),
             Gen.option(arbitrary[MessageId]),
-            Gen.option(arbitrary[MessageType])
+            Gen.option(arbitrary[MessageType]),
+            Gen.option(arbitrary[ClientId])
           ) {
-            (eoriNumber, movementType, movementId, messageId, messageType) =>
+            (eoriNumber, movementType, movementId, messageId, messageType, clientId) =>
               when(
                 mockConnector.postMessageType(
                   eqTo(AmendmentAcceptance),
@@ -89,7 +91,8 @@ class AuditingServiceSpec
                   eqTo(messageId),
                   eqTo(eoriNumber),
                   eqTo(movementType),
-                  eqTo(messageType)
+                  eqTo(messageType),
+                  eqTo(clientId)
                 )(any(), any())
               )
                 .thenReturn(Future.successful(()))
@@ -104,7 +107,8 @@ class AuditingServiceSpec
                   messageId,
                   eoriNumber,
                   movementType,
-                  messageType
+                  messageType,
+                  clientId
                 )
               ) {
                 _ =>
@@ -117,7 +121,8 @@ class AuditingServiceSpec
                     eqTo(messageId),
                     eqTo(eoriNumber),
                     eqTo(movementType),
-                    eqTo(messageType)
+                    eqTo(messageType),
+                    eqTo(clientId)
                   )(any(), any())
               }
           }
@@ -127,9 +132,10 @@ class AuditingServiceSpec
             Gen.option(arbitrary[MovementType]),
             Gen.option(arbitrary[MovementId]),
             Gen.option(arbitrary[MessageId]),
-            Gen.option(arbitrary[MessageType])
+            Gen.option(arbitrary[MessageType]),
+            Gen.option(arbitrary[ClientId])
           ) {
-            (eoriNumber, movementType, movementId, messageId, messageType) =>
+            (eoriNumber, movementType, movementId, messageId, messageType, clientId) =>
               val exception = new IllegalStateException("failed")
               when(
                 mockConnector.postMessageType(
@@ -141,7 +147,8 @@ class AuditingServiceSpec
                   eqTo(messageId),
                   eqTo(eoriNumber),
                   eqTo(movementType),
-                  eqTo(messageType)
+                  eqTo(messageType),
+                  eqTo(clientId)
                 )(any(), any())
               ).thenReturn(Future.failed(exception))
 
@@ -161,7 +168,8 @@ class AuditingServiceSpec
                   messageId,
                   eoriNumber,
                   movementType,
-                  messageType
+                  messageType,
+                  clientId
                 )
               ) {
                 _ =>
@@ -174,7 +182,8 @@ class AuditingServiceSpec
                     eqTo(messageId),
                     eqTo(eoriNumber),
                     eqTo(movementType),
-                    eqTo(messageType)
+                    eqTo(messageType),
+                    eqTo(clientId)
                   )(any(), any())
                   verify(Harness.logger0, times(1)).warn(eqTo("Unable to audit payload due to an exception"), eqTo(exception))
               }
@@ -205,7 +214,8 @@ class AuditingServiceSpec
             eqTo(messageId),
             eqTo(eoriNumber),
             eqTo(movementType),
-            eqTo(messageType)
+            eqTo(messageType),
+            eqTo(Some(ClientId("2345")))
           )(any(), any())
         )
           .thenReturn(Future.successful(()))
@@ -218,7 +228,8 @@ class AuditingServiceSpec
             messageId,
             eoriNumber,
             movementType,
-            messageType
+            messageType,
+            Some(ClientId("2345"))
           )
         ) {
           _ =>
@@ -229,7 +240,8 @@ class AuditingServiceSpec
               eqTo(messageId),
               eqTo(eoriNumber),
               eqTo(movementType),
-              eqTo(messageType)
+              eqTo(messageType),
+              eqTo(Some(ClientId("2345")))
             )(any(), any())
         }
     }
@@ -252,7 +264,8 @@ class AuditingServiceSpec
             eqTo(messageId),
             eqTo(eoriNumber),
             eqTo(movementType),
-            eqTo(messageType)
+            eqTo(messageType),
+            eqTo(Some(ClientId("2345")))
           )(any(), any())
         ).thenReturn(Future.failed(exception))
 
@@ -270,7 +283,8 @@ class AuditingServiceSpec
             messageId,
             eoriNumber,
             movementType,
-            messageType
+            messageType,
+            Some(ClientId("2345"))
           )
         ) {
           _ =>
@@ -281,7 +295,8 @@ class AuditingServiceSpec
               eqTo(messageId),
               eqTo(eoriNumber),
               eqTo(movementType),
-              eqTo(messageType)
+              eqTo(messageType),
+              eqTo(Some(ClientId("2345")))
             )(any(), any())
             verify(Harness.logger0, times(1)).warn(eqTo("Unable to audit payload due to an exception"), eqTo(exception))
         }


### PR DESCRIPTION
1. Get the Enrolment number and clientId from transit-movements
2. Pass clientId and Enrolment Number to auditing service.