### PR TITLE
Send hardcoded header value to auditing

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsrouter/connectors/AuditingConnector.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/connectors/AuditingConnector.scala
@@ -40,6 +40,7 @@ import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
 import uk.gov.hmrc.transitmovementsrouter.metrics.HasMetrics
 import uk.gov.hmrc.transitmovementsrouter.metrics.MetricsKeys
+import uk.gov.hmrc.transitmovementsrouter.models.APIVersionHeader
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType
 import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
@@ -69,7 +70,8 @@ trait AuditingConnector {
     movementType: Option[MovementType],
     messageType: Option[MessageType],
     clientId: Option[ClientId],
-    isTransitional: Boolean
+    isTransitional: Boolean,
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -83,7 +85,8 @@ trait AuditingConnector {
     enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
     messageType: Option[MessageType],
-    clientId: Option[ClientId]
+    clientId: Option[ClientId],
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -112,7 +115,8 @@ class AuditingConnectorImpl @Inject() (httpClient: HttpClientV2, val metrics: Me
     movementType: Option[MovementType] = None,
     messageType: Option[MessageType] = None,
     clientId: Option[ClientId] = None,
-    isTransitional: Boolean
+    isTransitional: Boolean,
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -123,7 +127,8 @@ class AuditingConnectorImpl @Inject() (httpClient: HttpClientV2, val metrics: Me
       HeaderNames.CONTENT_TYPE -> contentType,
       "X-ContentLength"        -> contentLength.toString,
       "X-Audit-Meta-Path"      -> path,
-      "X-Audit-Source"         -> "transit-movements-router"
+      "X-Audit-Source"         -> "transit-movements-router",
+      "APIVersion"             -> s"${versionHeader.value}"
     )
 
     val allHeaders: Seq[(String, String)] = originalHeaders
@@ -156,7 +161,8 @@ class AuditingConnectorImpl @Inject() (httpClient: HttpClientV2, val metrics: Me
     enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
     messageType: Option[MessageType],
-    clientId: Option[ClientId]
+    clientId: Option[ClientId],
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -170,7 +176,8 @@ class AuditingConnectorImpl @Inject() (httpClient: HttpClientV2, val metrics: Me
       .withClientId(clientId)
       .setHeader(
         "X-Audit-Source"         -> "transit-movements-router",
-        HeaderNames.CONTENT_TYPE -> MimeTypes.JSON
+        HeaderNames.CONTENT_TYPE -> MimeTypes.JSON,
+        "APIVersion"             -> s"${versionHeader.value}"
       )
       .withBody(Json.toJson(details))
       .execute[HttpResponse]

--- a/app/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesController.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/controllers/MessagesController.scala
@@ -49,6 +49,7 @@ import uk.gov.hmrc.transitmovementsrouter.controllers.stream.StreamingParsers
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType.NCTSRequestedMissingMovement
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType.NCTSToTraderSubmissionSuccessful
 import uk.gov.hmrc.transitmovementsrouter.models.*
+import uk.gov.hmrc.transitmovementsrouter.models.APIVersionHeader.v2_1
 import uk.gov.hmrc.transitmovementsrouter.models.requests.MessageUpdate
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanResponse.DownloadUrl
 import uk.gov.hmrc.transitmovementsrouter.models.responses.UpscanFailedResponse
@@ -237,7 +238,8 @@ class MessagesController @Inject() (
               None,
               Some(messageType.movementType),
               Some(messageType),
-              None
+              None,
+              APIVersionHeader.v2_1 // TODO: Fix this to get a response from transit movements to determine whether or not the version is 2.1 / 3.0
             )
           (err, Option(messageType))
         }
@@ -252,7 +254,8 @@ class MessagesController @Inject() (
           movementType = Some(messageType.movementType),
           messageType = Some(messageType),
           clientId = persistenceResponse.clientId,
-          isTransitional = persistenceResponse.isTransitional
+          isTransitional = persistenceResponse.isTransitional,
+          APIVersionHeader.v2_1 // TODO: Fix this to get a response from transit movements to determine whether or not the version is 2.1 / 3.0
         )
         _ = auditService.auditStatusEvent(
           NCTSToTraderSubmissionSuccessful,
@@ -262,7 +265,8 @@ class MessagesController @Inject() (
           enrolmentEORI = Some(persistenceResponse.eori),
           Some(messageType.movementType),
           Some(messageType),
-          clientId = persistenceResponse.clientId
+          clientId = persistenceResponse.clientId,
+          APIVersionHeader.v2_1 // TODO: Fix this to get a response from transit movements to determine whether or not the version is 2.1 / 3.0
         )
         _ = logIncomingSuccess(movementId, triggerId, persistenceResponse.messageId, messageType)
       } yield persistenceResponse)

--- a/app/uk/gov/hmrc/transitmovementsrouter/services/AuditingService.scala
+++ b/app/uk/gov/hmrc/transitmovementsrouter/services/AuditingService.scala
@@ -24,6 +24,7 @@ import play.api.Logging
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.transitmovementsrouter.connectors.AuditingConnector
+import uk.gov.hmrc.transitmovementsrouter.models.APIVersionHeader
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType
 import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
@@ -47,7 +48,8 @@ trait AuditingService {
     enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
     messageType: Option[MessageType],
-    clientId: Option[ClientId]
+    clientId: Option[ClientId],
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -64,7 +66,8 @@ trait AuditingService {
     movementType: Option[MovementType],
     messageType: Option[MessageType],
     clientId: Option[ClientId],
-    isTransitional: Boolean
+    isTransitional: Boolean,
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -85,7 +88,8 @@ class AuditingServiceImpl @Inject() (auditingConnector: AuditingConnector) exten
     movementType: Option[MovementType],
     messageType: Option[MessageType],
     clientId: Option[ClientId],
-    isTransitional: Boolean
+    isTransitional: Boolean,
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
@@ -102,7 +106,8 @@ class AuditingServiceImpl @Inject() (auditingConnector: AuditingConnector) exten
         movementType,
         messageType,
         clientId,
-        isTransitional
+        isTransitional,
+        versionHeader
       )
       .recover { case NonFatal(e) =>
         logger.warn("Unable to audit payload due to an exception", e)
@@ -116,13 +121,15 @@ class AuditingServiceImpl @Inject() (auditingConnector: AuditingConnector) exten
     enrolmentEORI: Option[EoriNumber],
     movementType: Option[MovementType],
     messageType: Option[MessageType],
-    clientId: Option[ClientId]
+    clientId: Option[ClientId],
+    versionHeader: APIVersionHeader
   )(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[Unit] =
-    auditingConnector.postStatus(auditType, payload, movementId, messageId, enrolmentEORI, movementType, messageType, clientId).recover { case NonFatal(e) =>
-      logger.warn("Unable to audit payload due to an exception", e)
+    auditingConnector.postStatus(auditType, payload, movementId, messageId, enrolmentEORI, movementType, messageType, clientId, versionHeader).recover {
+      case NonFatal(e) =>
+        logger.warn("Unable to audit payload due to an exception", e)
 
     }
 }

--- a/it/test/uk/gov/hmrc/transitmovementsrouter/connectors/AuditingConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/transitmovementsrouter/connectors/AuditingConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.transitmovementsrouter.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import io.lemonlabs.uri.Url
 import org.apache.pekko.stream.scaladsl.Source
 import org.mockito.Mockito.when
@@ -45,7 +45,8 @@ import uk.gov.hmrc.http.test.HttpClientV2Support
 import uk.gov.hmrc.transitmovementsrouter.config.AppConfig
 import uk.gov.hmrc.transitmovementsrouter.it.base.WiremockSuite
 import uk.gov.hmrc.transitmovementsrouter.it.generators.ModelGenerators
-import uk.gov.hmrc.transitmovementsrouter.models._
+import uk.gov.hmrc.transitmovementsrouter.models.*
+import uk.gov.hmrc.transitmovementsrouter.models.APIVersionHeader.v2_1
 import uk.gov.hmrc.transitmovementsrouter.models.requests.Details
 import uk.gov.hmrc.transitmovementsrouter.models.requests.Metadata
 import uk.gov.hmrc.transitmovementsrouter.utils.RouterHeaderNames.CLIENT_ID
@@ -112,12 +113,12 @@ class AuditingConnectorSpec
             Some(eori),
             Some(movementType),
             Some(messageType),
-            isTransitional = false
+            isTransitional = false,
+            versionHeader = APIVersionHeader.v2_1
           )
 
           // then the future should be ready
-          whenReady(future) { _ =>
-          }
+          whenReady(future) { _ => }
         }
 
         "return a successful future if the audit message was accepted with movementId, messageId & eoriNumber Optional header value" in forAll(
@@ -152,12 +153,12 @@ class AuditingConnectorSpec
             Some(eori),
             None,
             None,
-            isTransitional = false
+            isTransitional = false,
+            versionHeader = APIVersionHeader.v2_1
           )
 
           // then the future should be ready
-          whenReady(future) { _ =>
-          }
+          whenReady(future) { _ => }
         }
 
         "return a successful future if the audit message was accepted with movementType & messageType Optional header value" in forAll(
@@ -190,12 +191,12 @@ class AuditingConnectorSpec
             None,
             Some(movementType),
             Some(messageType),
-            isTransitional = false
+            isTransitional = false,
+            versionHeader = APIVersionHeader.v2_1
           )
 
           // then the future should be ready
-          whenReady(future) { _ =>
-          }
+          whenReady(future) { _ => }
         }
 
         "return a successful future if the audit message was accepted without any Optional header value" in {
@@ -223,12 +224,12 @@ class AuditingConnectorSpec
             None,
             None,
             None,
-            isTransitional = false
+            isTransitional = false,
+            versionHeader = APIVersionHeader.v2_1
           )
 
           // then the future should be ready
-          whenReady(future) { _ =>
-          }
+          whenReady(future) { _ => }
         }
 
         "return a failed future if the audit message was not accepted" - Seq(BAD_REQUEST, INTERNAL_SERVER_ERROR).foreach { statusCode =>
@@ -269,7 +270,8 @@ class AuditingConnectorSpec
               Some(eori),
               Some(movementType),
               Some(messageType),
-              isTransitional = false
+              isTransitional = false,
+              versionHeader = APIVersionHeader.v2_1
             )
 
             val result = future
@@ -282,8 +284,7 @@ class AuditingConnectorSpec
               }
 
             // then the future should be ready
-            whenReady(result) { _ =>
-            }
+            whenReady(result) { _ => }
           }
         }
 
@@ -331,12 +332,12 @@ class AuditingConnectorSpec
         eori,
         movementType,
         messageType,
-        Some(ClientId("1234"))
+        Some(ClientId("1234")),
+        APIVersionHeader.v2_1
       )
 
       // then the future should be ready
-      whenReady(future) { _ =>
-      }
+      whenReady(future) { _ => }
     }
 
     "return a failed future if the audit message was not accepted" - Seq(BAD_REQUEST, INTERNAL_SERVER_ERROR).foreach { statusCode =>
@@ -378,7 +379,8 @@ class AuditingConnectorSpec
           eori,
           movementType,
           messageType,
-          Some(ClientId("1234"))
+          Some(ClientId("1234")),
+          APIVersionHeader.v2_1
         )
 
         val result = future
@@ -391,8 +393,7 @@ class AuditingConnectorSpec
           }
 
         // then the future should be ready
-        whenReady(result) { _ =>
-        }
+        whenReady(result) { _ => }
       }
     }
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/controllers/MessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/controllers/MessageControllerSpec.scala
@@ -922,7 +922,8 @@ class MessageControllerSpec
           eqTo(None),
           eqTo(Some(messageType.movementType)),
           eqTo(Some(messageType)),
-          eqTo(None)
+          eqTo(None),
+          eqTo(APIVersionHeader.v2_1)
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(Future.successful(()))
 
@@ -935,7 +936,8 @@ class MessageControllerSpec
           eqTo(Some(eoriNumber)),
           eqTo(Some(messageType.movementType)),
           eqTo(Some(messageType)),
-          eqTo(clientId)
+          eqTo(clientId),
+          eqTo(APIVersionHeader.v2_1)
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(Future.successful(()))
 
@@ -965,7 +967,8 @@ class MessageControllerSpec
         eqTo(Some(messageType.movementType)),
         eqTo(Some(messageType)),
         eqTo(clientId),
-        eqTo(isTransitional)
+        eqTo(isTransitional),
+        eqTo(APIVersionHeader.v2_1)
       )(any[HeaderCarrier](), any[ExecutionContext]())
       verify(mockAuditingService, times(1)).auditStatusEvent(
         eqTo(NCTSToTraderSubmissionSuccessful),
@@ -975,7 +978,8 @@ class MessageControllerSpec
         eqTo(Some(eoriNumber)),
         eqTo(Some(messageType.movementType)),
         eqTo(Some(messageType)),
-        eqTo(clientId)
+        eqTo(clientId),
+        eqTo(APIVersionHeader.v2_1)
       )(any[HeaderCarrier], any[ExecutionContext])
 
       verify(mockAuditingService, times(0)).auditStatusEvent(
@@ -986,7 +990,8 @@ class MessageControllerSpec
         eqTo(None),
         eqTo(Some(messageType.movementType)),
         eqTo(Some(messageType)),
-        eqTo(None)
+        eqTo(None),
+        eqTo(APIVersionHeader.v2_1)
       )(any[HeaderCarrier], any[ExecutionContext])
     }
     "must return BAD_REQUEST when the X-Message-Type header is missing or body seems to not contain an appropriate root tag" in {
@@ -1045,7 +1050,8 @@ class MessageControllerSpec
           eqTo(None),
           eqTo(Some(MessageType.MrnAllocated.movementType)),
           eqTo(Some(MessageType.MrnAllocated)),
-          eqTo(None)
+          eqTo(None),
+          eqTo(APIVersionHeader.v2_1)
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(Future.successful(()))
 
@@ -1058,7 +1064,8 @@ class MessageControllerSpec
           eqTo(None),
           eqTo(Some(MessageType.MrnAllocated.movementType)),
           eqTo(Some(MessageType.MrnAllocated)),
-          eqTo(None)
+          eqTo(None),
+          eqTo(APIVersionHeader.v2_1)
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(Future.successful(()))
 
@@ -1079,7 +1086,8 @@ class MessageControllerSpec
         eqTo(None),
         eqTo(Some(MessageType.MrnAllocated.movementType)),
         eqTo(Some(MessageType.MrnAllocated)),
-        eqTo(None)
+        eqTo(None),
+        eqTo(APIVersionHeader.v2_1)
       )(any[HeaderCarrier], any[ExecutionContext])
       verify(mockAuditingService, times(1)).auditStatusEvent(
         eqTo(NCTSRequestedMissingMovement),
@@ -1089,7 +1097,8 @@ class MessageControllerSpec
         eqTo(None),
         eqTo(Some(MessageType.MrnAllocated.movementType)),
         eqTo(Some(MessageType.MrnAllocated)),
-        eqTo(None)
+        eqTo(None),
+        eqTo(APIVersionHeader.v2_1)
       )(any[HeaderCarrier], any[ExecutionContext])
 
       verify(mockAuditingService, times(0)).auditMessageEvent(
@@ -1103,7 +1112,8 @@ class MessageControllerSpec
         eqTo(Some(MessageType.MrnAllocated.movementType)),
         eqTo(Some(MessageType.MrnAllocated)),
         eqTo(None),
-        any()
+        any(),
+        eqTo(APIVersionHeader.v2_1)
       )(any[HeaderCarrier](), any[ExecutionContext]())
     }
 
@@ -1121,7 +1131,8 @@ class MessageControllerSpec
           eqTo(None),
           eqTo(Some(MessageType.MrnAllocated.movementType)),
           eqTo(Some(MessageType.DeclarationAmendment)),
-          eqTo(None)
+          eqTo(None),
+          eqTo(APIVersionHeader.v2_1)
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(Future.successful(()))
 
@@ -1134,7 +1145,8 @@ class MessageControllerSpec
           eqTo(None),
           eqTo(Some(MessageType.MrnAllocated.movementType)),
           eqTo(Some(MessageType.DeclarationAmendment)),
-          eqTo(None)
+          eqTo(None),
+          eqTo(APIVersionHeader.v2_1)
         )(any[HeaderCarrier], any[ExecutionContext])
       ).thenReturn(Future.successful(()))
 
@@ -1162,7 +1174,8 @@ class MessageControllerSpec
       eqTo(None),
       eqTo(Some(MessageType.MrnAllocated.movementType)),
       eqTo(Some(MessageType.MrnAllocated)),
-      eqTo(None)
+      eqTo(None),
+      eqTo(APIVersionHeader.v2_1)
     )(any[HeaderCarrier], any[ExecutionContext])
     verify(mockAuditingService, times(0)).auditStatusEvent(
       eqTo(NCTSRequestedMissingMovement),
@@ -1172,7 +1185,8 @@ class MessageControllerSpec
       eqTo(None),
       eqTo(Some(MessageType.MrnAllocated.movementType)),
       eqTo(Some(MessageType.MrnAllocated)),
-      eqTo(None)
+      eqTo(None),
+      eqTo(APIVersionHeader.v2_1)
     )(any[HeaderCarrier], any[ExecutionContext])
   }
 

--- a/test/uk/gov/hmrc/transitmovementsrouter/services/AuditingServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsrouter/services/AuditingServiceSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.transitmovementsrouter.services
 
 import org.apache.pekko.stream.scaladsl.Source
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.ArgumentMatchers.eq as eqTo
 import org.mockito.Mockito.reset
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -41,6 +41,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.transitmovementsrouter.connectors.AuditingConnector
 import uk.gov.hmrc.transitmovementsrouter.generators.TestModelGenerators
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType.AmendmentAcceptance
+import uk.gov.hmrc.transitmovementsrouter.models.APIVersionHeader
 import uk.gov.hmrc.transitmovementsrouter.models.AuditType
 import uk.gov.hmrc.transitmovementsrouter.models.ClientId
 import uk.gov.hmrc.transitmovementsrouter.models.EoriNumber
@@ -93,7 +94,8 @@ class AuditingServiceSpec
               eqTo(movementType),
               eqTo(messageType),
               eqTo(clientId),
-              eqTo(isTransitional)
+              eqTo(isTransitional),
+              eqTo(APIVersionHeader.v2_1)
             )(any(), any())
           )
             .thenReturn(Future.successful(()))
@@ -110,7 +112,8 @@ class AuditingServiceSpec
               movementType,
               messageType,
               clientId,
-              isTransitional
+              isTransitional,
+              APIVersionHeader.v2_1
             )
           ) { _ =>
             verify(mockConnector, times(1)).postMessageType(
@@ -124,7 +127,8 @@ class AuditingServiceSpec
               eqTo(movementType),
               eqTo(messageType),
               eqTo(clientId),
-              eqTo(isTransitional)
+              eqTo(isTransitional),
+              eqTo(APIVersionHeader.v2_1)
             )(any(), any())
           }
         }
@@ -151,7 +155,8 @@ class AuditingServiceSpec
               eqTo(movementType),
               eqTo(messageType),
               eqTo(clientId),
-              eqTo(isTransitional)
+              eqTo(isTransitional),
+              eqTo(APIVersionHeader.v2_1)
             )(any(), any())
           ).thenReturn(Future.failed(exception))
 
@@ -173,7 +178,8 @@ class AuditingServiceSpec
               movementType,
               messageType,
               clientId,
-              isTransitional
+              isTransitional,
+              APIVersionHeader.v2_1
             )
           ) { _ =>
             verify(mockConnector, times(1)).postMessageType(
@@ -187,7 +193,8 @@ class AuditingServiceSpec
               eqTo(movementType),
               eqTo(messageType),
               eqTo(clientId),
-              eqTo(isTransitional)
+              eqTo(isTransitional),
+              eqTo(APIVersionHeader.v2_1)
             )(any(), any())
             verify(Harness.logger0, times(1)).warn(eqTo("Unable to audit payload due to an exception"), eqTo(exception))
           }
@@ -218,7 +225,8 @@ class AuditingServiceSpec
           eqTo(eoriNumber),
           eqTo(movementType),
           eqTo(messageType),
-          eqTo(Some(ClientId("2345")))
+          eqTo(Some(ClientId("2345"))),
+          eqTo(APIVersionHeader.v2_1)
         )(any(), any())
       )
         .thenReturn(Future.successful(()))
@@ -232,7 +240,8 @@ class AuditingServiceSpec
           eoriNumber,
           movementType,
           messageType,
-          Some(ClientId("2345"))
+          Some(ClientId("2345")),
+          APIVersionHeader.v2_1
         )
       ) { _ =>
         verify(mockConnector, times(1)).postStatus(
@@ -243,7 +252,8 @@ class AuditingServiceSpec
           eqTo(eoriNumber),
           eqTo(movementType),
           eqTo(messageType),
-          eqTo(Some(ClientId("2345")))
+          eqTo(Some(ClientId("2345"))),
+          eqTo(APIVersionHeader.v2_1)
         )(any(), any())
       }
     }
@@ -266,7 +276,8 @@ class AuditingServiceSpec
           eqTo(eoriNumber),
           eqTo(movementType),
           eqTo(messageType),
-          eqTo(Some(ClientId("2345")))
+          eqTo(Some(ClientId("2345"))),
+          eqTo(APIVersionHeader.v2_1)
         )(any(), any())
       ).thenReturn(Future.failed(exception))
 
@@ -285,7 +296,8 @@ class AuditingServiceSpec
           eoriNumber,
           movementType,
           messageType,
-          Some(ClientId("2345"))
+          Some(ClientId("2345")),
+          APIVersionHeader.v2_1
         )
       ) { _ =>
         verify(mockConnector, times(1)).postStatus(
@@ -296,7 +308,8 @@ class AuditingServiceSpec
           eqTo(eoriNumber),
           eqTo(movementType),
           eqTo(messageType),
-          eqTo(Some(ClientId("2345")))
+          eqTo(Some(ClientId("2345"))),
+          eqTo(APIVersionHeader.v2_1)
         )(any(), any())
         verify(Harness.logger0, times(1)).warn(eqTo("Unable to audit payload due to an exception"), eqTo(exception))
       }


### PR DESCRIPTION
Hardcoded temporarily until changes go into transit-movements to identify the movement version when coming back from EIS